### PR TITLE
Create doc during token save

### DIFF
--- a/Buddies/Notifications/NotificationService.swift
+++ b/Buddies/Notifications/NotificationService.swift
@@ -69,9 +69,9 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate, Messaging
         
         guard let uid = user?.uid else { return }
 
-        collection.document(uid).updateData([
+        collection.document(uid).setData([
                 "notification_token" : fcmToken
-        ]) {err in
+        ], merge: true) {err in
             if let err = err {
                 print("Error updating document: \(err)")
             }

--- a/BuddiesTests/NotificationServiceTest.swift
+++ b/BuddiesTests/NotificationServiceTest.swift
@@ -105,6 +105,17 @@ class NotificationServiceTest: XCTestCase {
             override func updateData(_ fields: [AnyHashable : Any], completion: ((Error?) -> Void)? = nil) {
                 test_token = fields[AnyHashable("notification_token")] as? String
             }
+
+            override func setData(_ documentData: [String : Any], merge: Bool, completion: ((Error?) -> Void)? = nil) {
+                test_token = documentData["notification_token"] as? String
+                if (test_token?.count == 0) {
+                    let err = NSError(domain: "None", code: -1, userInfo: ["name": "none"])
+                    guard let onErr = completion else { return }
+                    
+                    onErr(err)
+                }
+            }
+            
             // THANK YOU STACK OVERFLOW: https://stackoverflow.com/a/47272501
             init(workaround _: Void = ()) {}
         }
@@ -133,6 +144,18 @@ class NotificationServiceTest: XCTestCase {
             collection: collection
         )
         XCTAssert(collection.doc.test_token == "token_boi", "Saves token if user is authenticated.")
+    }
+    
+    func testTokenError() {
+        let notificationTester = NotificationService()
+        let collection = TestCollection()
+        let user = ExistingUser()
+        notificationTester.saveTokenToFirestore(
+            fcmToken: "",
+            user: user,
+            collection: collection
+        )
+        XCTAssert(true, "Does not crash on error throw")
     }
 }
 


### PR DESCRIPTION
We needed to do this because otherwise it throws an
error complaining about not having a document to
update. It will still update the document if it exists,
though, so the functionality should be the same.

This also includes an extra test for the NotificationService,
which should bring test coverage to 100% for that file.