### PR TITLE
Issue 15 topic crash

### DIFF
--- a/Buddies/Topics/TopicCollection.swift
+++ b/Buddies/Topics/TopicCollection.swift
@@ -11,7 +11,6 @@ import UIKit
 import FirebaseFirestore
 
 protocol TopicCollectionDelegate {
-    func updateTopicImage(index: Int) -> Void
     func updateTopicImages() -> Void
 }
 
@@ -25,14 +24,14 @@ class TopicCollection: NSObject {
         if let topic = Topic(id: id, data: data) {
             topic.image = image
             self.topics.append(topic)
-            self.delegate?.updateTopicImage(index: self.topics.count - 1)
+            self.delegate?.updateTopicImages()
         }
     }
     
     func addWithoutImage(using data: [String: Any]?, for id: String){
         if let topic = Topic(id: id, data: data){
             self.topics.append(topic)
-            self.delegate?.updateTopicImage(index: self.topics.count - 1)
+            self.delegate?.updateTopicImages()
         }
     }
     
@@ -42,7 +41,7 @@ class TopicCollection: NSObject {
             if let image = UIImage(data: imageData),
                 let idx = topics.firstIndex(where: {$0.id == id})  {
                 topics[idx].image = image
-                delegate?.updateTopicImage(index: idx)
+                self.delegate?.updateTopicImages()
             } else {
                 print("Failed to load downloaded Topic image for \(id)")
             }

--- a/Buddies/Topics/TopicsVC.swift
+++ b/Buddies/Topics/TopicsVC.swift
@@ -23,12 +23,7 @@ class TopicsVC: UICollectionViewController, TopicCollectionDelegate {
         
         collectionView?.contentInset = UIEdgeInsets(top: 23, left: 10, bottom: 10, right: 10)
     }
-
-    func updateTopicImage(index: Int) {
-        let indexPath = IndexPath(item: index, section: 0)
-        collectionView.reloadItems(at: [indexPath])
-    }
-
+    
     func updateTopicImages() {
         collectionView.reloadData()
     }

--- a/Buddies/Utilities/Initialization.swift
+++ b/Buddies/Utilities/Initialization.swift
@@ -13,6 +13,7 @@ import UIKit
 class AppContent {
     static func setup(){
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        appDelegate.topicCollection.topics = []
         appDelegate.topicCollection.loadTopics()
     }
 }

--- a/BuddiesTests/Topics/TopicCollectionTests.swift
+++ b/BuddiesTests/Topics/TopicCollectionTests.swift
@@ -14,12 +14,8 @@ class TopicCollectionTests: XCTestCase {
     
     class MockCollectioDelegate: TopicCollectionDelegate {
         var fullUpdates = 0
-        var specificUpdates = [Int]()
         func updateTopicImages() {
             fullUpdates += 1
-        }
-        func updateTopicImage(index: Int) {
-            specificUpdates.append(index)
         }
     }
     
@@ -60,9 +56,7 @@ class TopicCollectionTests: XCTestCase {
         XCTAssert(collection.topics[1].id == "2")
         XCTAssert(collection.topics[1].name == "jake")
         
-        XCTAssert(delegate.fullUpdates == 0)
-        let sorted = delegate.specificUpdates.sorted()
-        XCTAssert(sorted.elementsEqual(stride(from: 0, to: collection.topics.count, by: 1)))
+        XCTAssert(delegate.fullUpdates == 2)
     }
     
     func testAddFromStorageInvalid(){
@@ -78,8 +72,6 @@ class TopicCollectionTests: XCTestCase {
         XCTAssert(collection.topics.count == 0)
         
         XCTAssert(delegate.fullUpdates == 0)
-        let sorted = delegate.specificUpdates.sorted()
-        XCTAssert(sorted.elementsEqual(stride(from: 0, to: collection.topics.count, by: 1)))
 
     }
     
@@ -100,9 +92,7 @@ class TopicCollectionTests: XCTestCase {
         XCTAssert(collection.topics[0].id == "1")
         XCTAssert(collection.topics[0].name == "jake")
         
-        XCTAssert(delegate.fullUpdates == 0)
-        let sorted = delegate.specificUpdates.sorted()
-        XCTAssert(sorted.elementsEqual(stride(from: 0, to: collection.topics.count, by: 1)))
+        XCTAssert(delegate.fullUpdates == 1)
     }
     
     
@@ -130,10 +120,7 @@ class TopicCollectionTests: XCTestCase {
         XCTAssert(collection.topics[1].id == "2")
         XCTAssert(collection.topics[1].name == "jake")
         
-        XCTAssert(delegate.fullUpdates == 0)
-        let sorted = delegate.specificUpdates.sorted()
-        XCTAssert(sorted.elementsEqual(stride(from: 0, to: collection.topics.count, by: 1)))
-        
+        XCTAssert(delegate.fullUpdates == 2)
         
     }
     
@@ -150,9 +137,6 @@ class TopicCollectionTests: XCTestCase {
         XCTAssert(collection.topics.count == 0)
         
         XCTAssert(delegate.fullUpdates == 0)
-        let sorted = delegate.specificUpdates.sorted()
-        XCTAssert(sorted.elementsEqual(stride(from: 0, to: collection.topics.count, by: 1)))
-        
     }
     
     func testAddWithoutImageMixed(){
@@ -172,9 +156,7 @@ class TopicCollectionTests: XCTestCase {
         XCTAssert(collection.topics[0].id == "1")
         XCTAssert(collection.topics[0].name == "jake")
         
-        XCTAssert(delegate.fullUpdates == 0)
-        let sorted = delegate.specificUpdates.sorted()
-        XCTAssert(sorted.elementsEqual(stride(from: 0, to: collection.topics.count, by: 1)))
+        XCTAssert(delegate.fullUpdates == 1)
     }
     
    
@@ -208,7 +190,8 @@ class TopicCollectionTests: XCTestCase {
                 XCTAssert(collection.topics[i].image == nil)
             }
         }
-        XCTAssert(delegate.specificUpdates.elementsEqual(elemsUpdated))
+        //the 0th, 2nd, and 6th item is updated
+        XCTAssert(delegate.fullUpdates == 4)
     }
     
     func testUpdateImageNoSuchTopic(){
@@ -235,6 +218,6 @@ class TopicCollectionTests: XCTestCase {
             XCTAssert(collection.topics[i].image == nil)
         }
         
-        XCTAssert(delegate.specificUpdates.isEmpty)
+        XCTAssert(delegate.fullUpdates == 0)
     }
 }


### PR DESCRIPTION
This should resolve #15 as well as our issue with duplicate Topics when you change users in the app.

Simply changes from reloading at an index to reloading all of the data.  

We avoid duplicates by clearing the Topics array at setup.