### PR TITLE
Round profile pics on all devices

### DIFF
--- a/Buddies/Profile/ProfileVC.swift
+++ b/Buddies/Profile/ProfileVC.swift
@@ -17,9 +17,12 @@ class ProfileVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        profilePic.layer.cornerRadius = profilePic.frame.size.width / 2
-
         loadProfileData()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        profilePic.layer.cornerRadius = profilePic.frame.size.width / 2
     }
     
     func loadProfileData(uid: String = Auth.auth().currentUser!.uid,


### PR DESCRIPTION
Profile pic wasn't a circle on iPad at least.

Not what we're developing for, but still was bugging me