### PR TITLE
BUD-112: Fix UnderlinedTextbox width on iPad

### DIFF
--- a/Buddies/Controls/UnderlinedTextbox.swift
+++ b/Buddies/Controls/UnderlinedTextbox.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 
+@IBDesignable
 class UnderlinedTextbox: UITextField, UITextFieldDelegate {
     let border: CALayer
     
@@ -16,37 +17,33 @@ class UnderlinedTextbox: UITextField, UITextFieldDelegate {
         super.init(coder: aDecoder)
         
         delegate = self
-        initBorder()
     }
     required override init(frame: CGRect) {
         border = CALayer()
         super.init(frame: frame)
 
         delegate = self
-        initBorder()
     }
     
-    func initBorder(){
+    override func draw(_ rect: CGRect) {
         self.borderStyle = .none
         
-        let width = CGFloat(2.0)
-        border.borderColor = ControlColors.fieldBorder.cgColor
+        border.backgroundColor = ControlColors.fieldBorder.cgColor
         border.frame = CGRect(
             x: 0,
-            y: self.frame.size.height-width,
-            width: self.frame.size.width + self.frame.size.height,
-            height: self.frame.size.height
+            y: self.bounds.height - 2,
+            width: self.bounds.size.width,
+            height: self.bounds.size.height
         )
-        border.borderWidth = width
         self.layer.addSublayer(border)
         self.layer.masksToBounds = true
     }
     
     func textFieldDidBeginEditing(_ textField: UITextField) {
-        border.borderColor = ControlColors.fieldBorderFocused.cgColor
+        border.backgroundColor = ControlColors.fieldBorderFocused.cgColor
     }
     
     func textFieldDidEndEditing(_ textField: UITextField) {
-        border.borderColor = ControlColors.fieldBorder.cgColor
+        border.backgroundColor = ControlColors.fieldBorder.cgColor
     }
 }

--- a/Buddies/Profile/ProfileVC.swift
+++ b/Buddies/Profile/ProfileVC.swift
@@ -19,10 +19,14 @@ class ProfileVC: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        profilePic?.imageView?.layer.cornerRadius = profilePic.bounds.size.width / 2
-        profilePic?.imageView?.clipsToBounds = true
-
         loadProfileData()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        profilePic.layer.cornerRadius = profilePic.frame.size.width / 2
+        profilePic.clipsToBounds = true
     }
     
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
Fixes #11 *[Login Fields not Centered]*

Also a commit to implement Luke's fix for round profile pics. I was able to repro the issue on my computer using the iPad 5th gen.