### PR TITLE
Add actual location text to activities

### DIFF
--- a/Buddies/Activities/ActivityDescriptionController.swift
+++ b/Buddies/Activities/ActivityDescriptionController.swift
@@ -38,7 +38,7 @@ class ActivityDescriptionController: UIView, UICollectionViewDataSource, UIColle
         self.curActivity = activity
         registerCollectionViews()
         joinButton?.layer.cornerRadius = 5
-        self.locationLabel.text = "Location"
+        self.locationLabel.text = activity.locationText
         self.titleLabel.text = activity.title
         self.descriptionLabel.text = activity.description
         

--- a/Buddies/Activities/ActivityTableVC.swift
+++ b/Buddies/Activities/ActivityTableVC.swift
@@ -135,8 +135,7 @@ class ActivityTableVC: UITableViewController {
         
         cell.titleLabel.text = activity.title
         cell.descriptionLabel.text = activity.description
-        cell.locationLabel.text = String(activity.location.latitude) + ", " + String(activity.location.longitude)
-        
+        cell.locationLabel.text = activity.locationText
         let dateRange = DateInterval(start: activity.startTime.dateValue(),
                                      end: activity.endTime.dateValue())
         

--- a/Buddies/Models/Activity.swift
+++ b/Buddies/Models/Activity.swift
@@ -44,7 +44,8 @@ class Activity {
     var startTime : Timestamp { didSet { onChange("start_time", startTime) } }
     var endTime : Timestamp { didSet { onChange("end_time", endTime) } }
     var topicIds : [String] { didSet { onChange("topic_ids", topicIds) } }
-    
+    var locationText: String { didSet { onChange("location_text", locationText) }}
+
     private func onChange(_ key: String, _ value: Any?) {
         delegate?.onInvalidateActivity(activity: self)
         delegate?.triggerServerUpdate(activityId: activityId, key: key, value: value)
@@ -60,6 +61,7 @@ class Activity {
          description: String,
          startTime: Timestamp,
          endTime: Timestamp,
+         locationText: String,
          topicIds: [String]) {
         self.delegate = delegate
         self.activityId = activityId
@@ -72,6 +74,7 @@ class Activity {
         self.startTime = startTime
         self.endTime = endTime
         self.topicIds = topicIds
+        self.locationText = locationText
     }
     
     static func from(snap: DocumentSnapshot, with delegate: ActivityInvalidationDelegate?) -> Activity? {
@@ -88,7 +91,8 @@ class Activity {
         
         let activityId = snap.documentID
         let description = data["description"] as? String ?? ""
-        
+        let locationText = data["location_text"] as? String ?? "🌍"
+
         return Activity(delegate: delegate,
                         activityId: activityId,
                         dateCreated: dateCreated,
@@ -99,6 +103,7 @@ class Activity {
                         description: description,
                         startTime: startTime,
                         endTime: endTime,
+                        locationText: locationText,
                         topicIds: topicIds)
     }
 

--- a/BuddiesTests/Activities/ActivityTableVCTests.swift
+++ b/BuddiesTests/Activities/ActivityTableVCTests.swift
@@ -109,6 +109,7 @@ class ActivityTableVCTests: XCTestCase {
                                 description: "activityDescription",
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
+                                locationText: "What up buddy",
                                 topicIds: [])
         
         let resCell = activityTableVC.format(cell: cell, using: activity, at: IndexPath(index: 0))
@@ -158,6 +159,7 @@ class ActivityTableVCTests: XCTestCase {
                                 description: "activityDescription",
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
+                                locationText: "What up buddy",
                                 topicIds: [])
         
         let resCell = activityTableVC.format(cell: cell, using: activity, at: IndexPath(index: 0))
@@ -205,6 +207,7 @@ class ActivityTableVCTests: XCTestCase {
                                 description: "activityDescription",
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
+                                locationText: "What up buddy",
                                 topicIds: [])
         
         let resCell = activityTableVC.format(cell: cell, using: activity, at: IndexPath(index: 0))
@@ -232,6 +235,7 @@ class ActivityTableVCTests: XCTestCase {
                                 description: "activityDescription",
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
+                                locationText: "What up buddy",
                                 topicIds: [])
         
         let activity2 = Activity(delegate: nil,
@@ -244,6 +248,7 @@ class ActivityTableVCTests: XCTestCase {
                                 description: "activityDescription",
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
+                                locationText: "What up buddy",
                                 topicIds: [])
         
         activityTableVC.activities = [[activity, activity2]]

--- a/BuddiesTests/Activities/ActivityTableVCTests.swift
+++ b/BuddiesTests/Activities/ActivityTableVCTests.swift
@@ -120,7 +120,7 @@ class ActivityTableVCTests: XCTestCase {
         
         XCTAssert(resCell.titleLabel.text == "activityTitle", "Cell Description correctly set")
         
-        XCTAssert(resCell.locationLabel.text == "\(Double(1)), \(Double(2))", "Cell location correctly set")
+        XCTAssert(resCell.locationLabel.text == "What up buddy", "Cell location correctly set")
         
         XCTAssert(resCell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
     }
@@ -170,7 +170,7 @@ class ActivityTableVCTests: XCTestCase {
         
         XCTAssert(resCell.titleLabel.text == "activityTitle", "Cell Description correctly set")
         
-        XCTAssert(resCell.locationLabel.text == "\(Double(1)), \(Double(2))", "Cell location correctly set")
+        XCTAssert(resCell.locationLabel.text == "What up buddy", "Cell location correctly set")
         
         XCTAssert(resCell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
     }
@@ -218,7 +218,7 @@ class ActivityTableVCTests: XCTestCase {
         
         XCTAssert(resCell.titleLabel.text == "activityTitle", "Cell Description correctly set")
         
-        XCTAssert(resCell.locationLabel.text == "\(Double(1)), \(Double(2))", "Cell location correctly set")
+        XCTAssert(resCell.locationLabel.text == "What up buddy", "Cell location correctly set")
         
         XCTAssert(!resCell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
     }

--- a/BuddiesTests/Models/ActivityTests.swift
+++ b/BuddiesTests/Models/ActivityTests.swift
@@ -68,6 +68,7 @@ class ActivityTests: XCTestCase {
                               description: "description",
                               startTime: Timestamp(date: Date()),
                               endTime: Timestamp(date: Date()),
+                              locationText: "What up buddy",
                               topicIds: [])
         
         XCTAssert(a.activityId == "activityId")


### PR DESCRIPTION
This adds the location text that @gyurisic saves to the views. Defaults to a globe emoji for places without a location text (e.g. places created before grant's change).

![img_bc188b5906a4-1](https://user-images.githubusercontent.com/6265975/53208865-6db82880-3606-11e9-98ad-5b054539d381.jpeg)
