### PR TITLE
Filter for Date range and Location range from search bar

### DIFF
--- a/Buddies.xcodeproj/project.pbxproj
+++ b/Buddies.xcodeproj/project.pbxproj
@@ -78,6 +78,7 @@
 		A95B958822133FA500453AEA /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95B958722133FA500453AEA /* User.swift */; };
 		A95B958A22133FB100453AEA /* Activity.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95B958922133FB100453AEA /* Activity.swift */; };
 		A95B958C2214B6A800453AEA /* DataAccessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95B958B2214B6A800453AEA /* DataAccessorTests.swift */; };
+		A9ADCDCC2223383300D12EB4 /* DateRangeSliderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9ADCDCB2223383300D12EB4 /* DateRangeSliderDelegate.swift */; };
 		A9B144AF220B4165004C614E /* SettingsVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B144AE220B4165004C614E /* SettingsVC.swift */; };
 		A9B144B1220C82A0004C614E /* AppDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9B144B0220C82A0004C614E /* AppDelegateTests.swift */; };
 		A9C9852C221E658C003462AC /* FilterSearchBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C9852B221E658C003462AC /* FilterSearchBar.swift */; };
@@ -199,6 +200,7 @@
 		A95B958722133FA500453AEA /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		A95B958922133FB100453AEA /* Activity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Activity.swift; sourceTree = "<group>"; };
 		A95B958B2214B6A800453AEA /* DataAccessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataAccessorTests.swift; sourceTree = "<group>"; };
+		A9ADCDCB2223383300D12EB4 /* DateRangeSliderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateRangeSliderDelegate.swift; sourceTree = "<group>"; };
 		A9B144AE220B4165004C614E /* SettingsVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsVC.swift; sourceTree = "<group>"; };
 		A9B144B0220C82A0004C614E /* AppDelegateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateTests.swift; sourceTree = "<group>"; };
 		A9C9852B221E658C003462AC /* FilterSearchBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterSearchBar.swift; sourceTree = "<group>"; };
@@ -502,6 +504,7 @@
 				A9E8BF492201F9D700C05F2C /* UnderlinedTextbox.swift */,
 				A9E8BF4B2201FB9C00C05F2C /* ControlColors.swift */,
 				58022669220BE5E90068E08E /* ToggleButton.swift */,
+				A9ADCDCB2223383300D12EB4 /* DateRangeSliderDelegate.swift */,
 			);
 			path = Controls;
 			sourceTree = "<group>";
@@ -893,6 +896,7 @@
 				A95B958522133DDB00453AEA /* DataAccessor.swift in Sources */,
 				458CE72E220D472200012637 /* MapItemSearchResult.swift in Sources */,
 				B688B47D221CCBAE0031A364 /* ActivityChatController.swift in Sources */,
+				A9ADCDCC2223383300D12EB4 /* DateRangeSliderDelegate.swift in Sources */,
 				45FED0AF220A657100B90C3B /* DeleteAccountVC.swift in Sources */,
 				450779E02210D7B00008D0DF /* RangeSeekSlider.swift in Sources */,
 				58FC665722188E0E00D13723 /* DateInterval.swift in Sources */,

--- a/Buddies/Activities/ActivityTableVC.swift
+++ b/Buddies/Activities/ActivityTableVC.swift
@@ -25,17 +25,17 @@ class ActivityTableVC: UITableViewController, FilterSearchBarDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.tableView.rowHeight = 110
-    }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        fetchAndLoadActivities()
         
         // We need to store a local so that the
         //  instance isn't deallocated along with
         //  the event handler!
         fab = FAB(for: self)
         fab.renderCreateActivityFab()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchAndLoadActivities()
     }
     
     

--- a/Buddies/Controls/DateRangeSliderDelegate.swift
+++ b/Buddies/Controls/DateRangeSliderDelegate.swift
@@ -1,0 +1,64 @@
+//
+//  DateRangeSliderDelegate.swift
+//  Buddies
+//
+//  Created by Jake Thurman on 2/24/19.
+//  Copyright © 2019 Jack and the Beans. All rights reserved.
+//
+
+import Foundation
+import CoreGraphics
+
+class DateRangeSliderDelegate : RangeSeekSliderDelegate {
+    static let instance = DateRangeSliderDelegate()
+
+    func getSliderString(sliderValue: CGFloat) -> String {
+        switch sliderValue {
+        case 1:
+            return "Today"
+        case 2:
+            return "Tomorrow"
+        case 3:
+            return "Next 3 Days"
+        case 4:
+            return "Next Week"
+        case 5:
+            return "Next 2 Weeks"
+        case 6:
+            return "Next Month"
+        default:
+            return "Today"
+        }
+    }
+    
+    func getSliderDate(sliderValue: CGFloat) -> Date {
+        var dateComponent = DateComponents()
+        
+        switch sliderValue {
+        case 1:
+            dateComponent.day = 0
+        case 2:
+            dateComponent.day = 1
+        case 3:
+            dateComponent.day = 3
+        case 4:
+            dateComponent.day = 7
+        case 5:
+            dateComponent.day = 14
+        case 6:
+            dateComponent.day = 30
+        default:
+            dateComponent.day = 0
+        }
+        
+        return Calendar.current.date(byAdding: dateComponent, to: Date())!
+    }
+    
+    func rangeSeekSlider(_ slider: RangeSeekSlider, stringForMinValue minValue: CGFloat) -> String? {
+        return getSliderString(sliderValue: minValue)
+    }
+    
+    func rangeSeekSlider(_ slider: RangeSeekSlider, stringForMaxValue maxValue: CGFloat) -> String? {
+        return getSliderString(sliderValue: maxValue)
+    }
+}

--- a/Buddies/Controls/DateRangeSliderDelegate.swift
+++ b/Buddies/Controls/DateRangeSliderDelegate.swift
@@ -12,53 +12,26 @@ import CoreGraphics
 class DateRangeSliderDelegate : RangeSeekSliderDelegate {
     static let instance = DateRangeSliderDelegate()
 
-    func getSliderString(sliderValue: CGFloat) -> String {
-        switch sliderValue {
-        case 1:
-            return "Today"
-        case 2:
-            return "Tomorrow"
-        case 3:
-            return "Next 3 Days"
-        case 4:
-            return "Next Week"
-        case 5:
-            return "Next 2 Weeks"
-        case 6:
-            return "Next Month"
-        default:
-            return "Today"
-        }
+    func getName(sliderIndex: CGFloat) -> String {
+        let values = ["", "Today", "Tomorrow", "Next 3 Days", "Next Week", "Next 2 Weeks", "Next Month"]
+        
+        return values[Int(sliderIndex)]
     }
     
-    func getSliderDate(sliderValue: CGFloat) -> Date {
+    static func getDate(sliderIndex: Int) -> Date {
         var dateComponent = DateComponents()
         
-        switch sliderValue {
-        case 1:
-            dateComponent.day = 0
-        case 2:
-            dateComponent.day = 1
-        case 3:
-            dateComponent.day = 3
-        case 4:
-            dateComponent.day = 7
-        case 5:
-            dateComponent.day = 14
-        case 6:
-            dateComponent.day = 30
-        default:
-            dateComponent.day = 0
-        }
+        let indexedValues = [ 0, 0, 1, 3, 7, 14, 30, 0 ]
+        dateComponent.day = indexedValues[sliderIndex]
         
-        return Calendar.current.date(byAdding: dateComponent, to: Date())!
+        return Calendar.current.date(byAdding: dateComponent, to: Date()) ?? Date()
     }
     
     func rangeSeekSlider(_ slider: RangeSeekSlider, stringForMinValue minValue: CGFloat) -> String? {
-        return getSliderString(sliderValue: minValue)
+        return getName(sliderIndex: minValue)
     }
     
     func rangeSeekSlider(_ slider: RangeSeekSlider, stringForMaxValue maxValue: CGFloat) -> String? {
-        return getSliderString(sliderValue: maxValue)
+        return getName(sliderIndex: maxValue)
     }
 }

--- a/Buddies/Controls/FilterSearchBar.swift
+++ b/Buddies/Controls/FilterSearchBar.swift
@@ -130,6 +130,7 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         container.translatesAutoresizingMaskIntoConstraints = false
         container.clipsToBounds = true
         container.layer.cornerRadius = 10
+        container.layer.zPosition = 2000
         
         let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
         blurView.translatesAutoresizingMaskIntoConstraints = false
@@ -160,8 +161,6 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
             ])
         let cancelButton = makeButton(saying: "Cancel", doing: #selector(self.closeFilterMenu))
         
-        
-        
         // put things together
         let containerChildren = [
             dateSliderLabel,
@@ -174,43 +173,29 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         container.addSubview(blurView)
         containerChildren.forEach { container.addSubview($0) }
         
-        let parent = superview!.superview! // Get the window in an ugly way
+        let parent = superview! // Get the window in an ugly way
         
         parent.addSubview(container)
         
-        // Size/Position
-        let containerConstraints = [
-            container.leftAnchor.constraint(equalTo: parent.leftAnchor),
-            container.rightAnchor.constraint(equalTo: parent.rightAnchor),
-            container.topAnchor.constraint(equalTo: parent.topAnchor, constant: frame.size.height),
-            container.bottomAnchor.constraint(equalTo: parent.bottomAnchor, constant: frame.size.height),
-            
-            // Blur view
-            blurView.heightAnchor.constraint(equalTo: container.heightAnchor),
-            blurView.widthAnchor.constraint(equalTo: container.widthAnchor),
-            
-            // Children to container
-            containerChildren.first!.topAnchor.constraint(equalTo: container.topAnchor, constant: 30),
-        ]
+        container.bindFrameToSuperviewBounds()
+        blurView.bindFrameToSuperviewBounds()
         
-        let constraintsBetweenChildren = [
+        // Size/Position
+        let childToContainerConstraints = [
+            dateSliderLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 20),
             dateSliderLabel.bottomAnchor.constraint(equalTo: dateSlider.topAnchor),
             dateSlider.bottomAnchor.constraint(equalTo: locationSliderLabel.topAnchor, constant: -20),
             locationSliderLabel.bottomAnchor.constraint(equalTo: locationRangeSlider.topAnchor),
-            locationRangeSlider.bottomAnchor.constraint(equalTo: innerFilterButton.topAnchor, constant: -20),
+            locationRangeSlider.bottomAnchor.constraint(equalTo: innerFilterButton.topAnchor, constant: -10),
             innerFilterButton.bottomAnchor.constraint(equalTo: cancelButton.topAnchor, constant: -20)
         ]
         
         let sideConstraints = containerChildren.flatMap({ [
-            $0.leftAnchor.constraint(equalTo: container.leftAnchor, constant: 15),
-            $0.rightAnchor.constraint(equalTo: container.rightAnchor, constant: -15),
+            $0.leftAnchor.constraint(equalTo: container.leftAnchor, constant: 25),
+            $0.rightAnchor.constraint(equalTo: container.rightAnchor, constant: -25),
         ] })
         
-        NSLayoutConstraint.activate(
-            containerConstraints
-            + sideConstraints
-            + constraintsBetweenChildren
-        )
+        NSLayoutConstraint.activate(sideConstraints + childToContainerConstraints)
         
         // Return useful components
         return (container: container, locationRangeSlider: locationRangeSlider, dateSlider: dateSlider)

--- a/Buddies/Controls/FilterSearchBar.swift
+++ b/Buddies/Controls/FilterSearchBar.swift
@@ -282,8 +282,8 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         // Store request params #NoRaceConditions
         self.lastSearchParams = myParams
         
-        let start = DateRangeSliderDelegate.instance.getSliderDate(sliderValue: CGFloat(myParams.dateMin))
-        let end = DateRangeSliderDelegate.instance.getSliderDate(sliderValue: CGFloat(myParams.dateMax))
+        let start = DateRangeSliderDelegate.getDate(sliderIndex: myParams.dateMin)
+        let end = DateRangeSliderDelegate.getDate(sliderIndex: myParams.dateMax)
         let distance = Int(FilterSearchBar.metersPerMile * myParams.maxMilesAway)
         
         // Load data from algolia!

--- a/Buddies/Controls/FilterSearchBar.swift
+++ b/Buddies/Controls/FilterSearchBar.swift
@@ -191,8 +191,8 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         ]
         
         let sideConstraints = containerChildren.flatMap({ [
-            $0.leftAnchor.constraint(equalTo: container.leftAnchor, constant: 25),
-            $0.rightAnchor.constraint(equalTo: container.rightAnchor, constant: -25),
+            $0.leftAnchor.constraint(equalTo: container.leftAnchor, constant: 35),
+            $0.rightAnchor.constraint(equalTo: container.rightAnchor, constant: -35),
         ] })
         
         NSLayoutConstraint.activate(sideConstraints + childToContainerConstraints)

--- a/Buddies/Controls/FilterSearchBar.swift
+++ b/Buddies/Controls/FilterSearchBar.swift
@@ -128,8 +128,6 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         let container = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
         container.backgroundColor = .clear
         container.translatesAutoresizingMaskIntoConstraints = false
-        container.clipsToBounds = true
-        container.layer.cornerRadius = 10
         container.layer.zPosition = 2000
         
         let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .light))

--- a/Buddies/Controls/FilterSearchBar.swift
+++ b/Buddies/Controls/FilterSearchBar.swift
@@ -9,7 +9,8 @@
 import Foundation
 import UIKit
 
-typealias SearchParams = (filterText: String?, when: DateInterval?, maxMetersAway: Int)
+typealias SearchParams = (filterText: String?, dateMin: Int, dateMax: Int, maxMilesAway: CGFloat)
+typealias FilterMenuElements = (container: UIView, locationRangeSlider: RangeSeekSlider, dateSlider: RangeSeekSlider)
 
 protocol FilterSearchBarDelegate {
     func endEditing()
@@ -18,16 +19,21 @@ protocol FilterSearchBarDelegate {
 }
 
 class FilterSearchBar : UISearchBar, UISearchBarDelegate {
+    private static let metersPerMile: CGFloat = 1609.344
+
     var api: AlgoliaSearch //Should only be changed by unit tests
-    
     var displayDelegate: FilterSearchBarDelegate?
     
-    // Default is a sentinal because XCode hates nil tuples :(
-    var lastSearchParams: SearchParams = ("", nil, 0)
+    // This just uses default values for now
+    //  these probably need to be stored in
+    //  firestore for BUD-41 🤔
+    var lastSearchParams: SearchParams = ("", 1, 6, 200)
+    var nextLocationRange: CGFloat?
+    var nextDateRange: (Int, Int)?
     
     var searchTimer: Timer?
-    var filterMenu: UIView?
-    
+    var filterMenu: FilterMenuElements?
+
     var cachedActivityIds: [String] = []
 
     override init(frame: CGRect) {
@@ -49,25 +55,9 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         self.delegate = self
         
         // Create the filter button
-        renderFilterButton()
-    }
-    
-    private func renderFilterButton() {
-        let bttn = UIButton(type: .custom)
-        
-        // Event handler
-        bttn.addTarget(self, action: #selector(self.onFilterTapped), for: .touchUpInside)
-        
-        // Design
-        bttn.setTitle("Filter", for: .normal)
-        bttn.backgroundColor = ControlColors.theme
-        bttn.setTitleColor(UIColor.white, for: .normal)
-        bttn.translatesAutoresizingMaskIntoConstraints = false
-        
-        // Rounded corners
-        bttn.clipsToBounds = true
-        bttn.layer.cornerRadius = 10
-        bttn.layer.maskedCorners = [.layerMaxXMaxYCorner, .layerMaxXMinYCorner]
+        let bttn = makeFilterButton(
+            doing: #selector(self.onFilterTapped),
+            rounding: [.layerMaxXMaxYCorner, .layerMaxXMinYCorner])
         
         addSubview(bttn)
         
@@ -80,56 +70,185 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         ])
     }
     
-    func renderNewFilterMenu() -> UIView {
-        let height = CGFloat(200)
-        let container = UIView(frame: CGRect(x: 0, y: 0, width: frame.width, height: height))
-        container.backgroundColor = UIColor(white: 0.98, alpha: 0.85)
-        container.translatesAutoresizingMaskIntoConstraints = false
+    private func makeFilterButton(doing action: Selector, rounding corners: CACornerMask) -> UIButton {
+        let bttn = makeButton(saying: "Filter", doing: action)
+        
+        // Design
+        bttn.backgroundColor = ControlColors.theme
+        bttn.setTitleColor(UIColor.white, for: .normal)
+        bttn.translatesAutoresizingMaskIntoConstraints = false
         
         // Rounded corners
+        bttn.clipsToBounds = true
+        bttn.layer.cornerRadius = 10
+        bttn.layer.maskedCorners = corners
+        
+        return bttn
+    }
+    
+    func makeSlider(from min: CGFloat, to max: CGFloat) -> RangeSeekSlider {
+        let slider = RangeSeekSlider(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        
+        slider.minValue = min
+        slider.maxValue = max
+        
+        slider.enableStep = true
+        slider.step = 1
+        
+        slider.tintColor = UIColor.lightGray
+        slider.handleColor = ControlColors.theme
+        slider.handleBorderColor = ControlColors.theme
+        slider.colorBetweenHandles = ControlColors.theme
+        slider.lineHeight = 2
+        slider.labelPadding = 2
+        slider.handleBorderWidth = 2
+        slider.minLabelColor = UIColor.black
+        slider.maxLabelColor = UIColor.black
+        slider.translatesAutoresizingMaskIntoConstraints = false
+        
+        return slider
+    }
+    
+    func makeLabel(saying text: String) -> UILabel {
+        let label = UILabel(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = text
+        return label
+    }
+    
+    func makeButton(saying text: String, doing action: Selector) -> UIButton {
+        let bttn = UIButton(type: .system)
+        bttn.setTitle(text, for: .normal)
+        bttn.translatesAutoresizingMaskIntoConstraints = false
+        bttn.addTarget(self, action: action, for: .touchUpInside)
+        return bttn
+    }
+    
+    func renderNewFilterMenu() -> FilterMenuElements {
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 0, height: 0))
+        container.backgroundColor = .clear
+        container.translatesAutoresizingMaskIntoConstraints = false
         container.clipsToBounds = true
         container.layer.cornerRadius = 10
         
-        // render
-        superview?.addSubview(container)
+        let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .light))
+        blurView.translatesAutoresizingMaskIntoConstraints = false
+        
+        // Make sliders
+        let dateSlider = makeSlider(from: 1, to: 6)
+        dateSlider.delegate = DateRangeSliderDelegate.instance
+        dateSlider.minDistance = 1
+        dateSlider.selectedMinValue = CGFloat(lastSearchParams.dateMin)
+        dateSlider.selectedMaxValue = CGFloat(lastSearchParams.dateMax)
+        
+        let locationRangeSlider = makeSlider(from: 1, to: 200)
+        locationRangeSlider.selectedMaxValue = lastSearchParams.maxMilesAway
+        locationRangeSlider.disableRange = true
+        
+        // Make labels
+        let dateSliderLabel = makeLabel(saying: "When:")
+        let locationSliderLabel = makeLabel(saying: "Distance (miles):")
+        
+        // Make buttons
+        let innerFilterButton = makeFilterButton(
+            doing: #selector(self.saveFilterMenu),
+            rounding: [
+                .layerMaxXMaxYCorner,
+                .layerMaxXMinYCorner,
+                .layerMinXMaxYCorner,
+                .layerMinXMinYCorner,
+            ])
+        let cancelButton = makeButton(saying: "Cancel", doing: #selector(self.closeFilterMenu))
+        
+        
+        
+        // put things together
+        let containerChildren = [
+            dateSliderLabel,
+            dateSlider,
+            locationSliderLabel,
+            locationRangeSlider,
+            innerFilterButton,
+            cancelButton,
+        ]
+        container.addSubview(blurView)
+        containerChildren.forEach { container.addSubview($0) }
+        
+        let parent = superview!.superview! // Get the window in an ugly way
+        
+        parent.addSubview(container)
         
         // Size/Position
-        NSLayoutConstraint.activate([
-            container.leftAnchor.constraint(equalTo: leftAnchor, constant: 10),
-            container.rightAnchor.constraint(equalTo: rightAnchor, constant: -10),
-            container.topAnchor.constraint(equalTo: bottomAnchor, constant: -10),
-            container.heightAnchor.constraint(equalToConstant: height)
-        ])
+        let containerConstraints = [
+            container.leftAnchor.constraint(equalTo: parent.leftAnchor),
+            container.rightAnchor.constraint(equalTo: parent.rightAnchor),
+            container.topAnchor.constraint(equalTo: parent.topAnchor, constant: frame.size.height),
+            container.bottomAnchor.constraint(equalTo: parent.bottomAnchor, constant: frame.size.height),
+            
+            // Blur view
+            blurView.heightAnchor.constraint(equalTo: container.heightAnchor),
+            blurView.widthAnchor.constraint(equalTo: container.widthAnchor),
+            
+            // Children to container
+            containerChildren.first!.topAnchor.constraint(equalTo: container.topAnchor, constant: 30),
+        ]
         
-        return container
+        let constraintsBetweenChildren = [
+            dateSliderLabel.bottomAnchor.constraint(equalTo: dateSlider.topAnchor),
+            dateSlider.bottomAnchor.constraint(equalTo: locationSliderLabel.topAnchor, constant: -20),
+            locationSliderLabel.bottomAnchor.constraint(equalTo: locationRangeSlider.topAnchor),
+            locationRangeSlider.bottomAnchor.constraint(equalTo: innerFilterButton.topAnchor, constant: -20),
+            innerFilterButton.bottomAnchor.constraint(equalTo: cancelButton.topAnchor, constant: -20)
+        ]
+        
+        let sideConstraints = containerChildren.flatMap({ [
+            $0.leftAnchor.constraint(equalTo: container.leftAnchor, constant: 15),
+            $0.rightAnchor.constraint(equalTo: container.rightAnchor, constant: -15),
+        ] })
+        
+        NSLayoutConstraint.activate(
+            containerConstraints
+            + sideConstraints
+            + constraintsBetweenChildren
+        )
+        
+        // Return useful components
+        return (container: container, locationRangeSlider: locationRangeSlider, dateSlider: dateSlider)
+    }
+    
+    @objc func closeFilterMenu() {
+        if let filterMenu = filterMenu {
+            filterMenu.container.removeFromSuperview()
+            self.filterMenu = nil
+        }
+    }
+    
+    @objc func saveFilterMenu() {
+        if let filterMenu = filterMenu {
+            self.nextLocationRange = filterMenu.locationRangeSlider.selectedMaxValue
+            self.nextDateRange = (Int(filterMenu.dateSlider.selectedMinValue), Int(filterMenu.dateSlider.selectedMaxValue))
+            
+            fetchAndLoadActivities()
+            
+            // Now go ahead and close
+            closeFilterMenu()
+        }
     }
     
     @objc func onFilterTapped() {
-        // Hide the filter menu...
-        if let filterMenu = filterMenu {
-            filterMenu.removeFromSuperview()
-            self.filterMenu = nil
-            return
-        }
+        // Chose existing just in the weird case that it is open
+        self.closeFilterMenu()
         
         // Show the filter menu...
         self.filterMenu = renderNewFilterMenu()
     }
     
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
-        searchTimer?.invalidate()
-        
         displayDelegate?.endEditing()
         fetchAndLoadActivities()
     }
     
-    func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
-        searchTimer?.invalidate()
-        fetchAndLoadActivities()
-    }
-    
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
-        
         // Create a timer to reload stuff so that we don't just call algolia for every time a letter is pressed in the search bar
         searchTimer?.invalidate()
         searchTimer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { _ in
@@ -140,12 +259,16 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
     func getSearchParams() -> SearchParams {
         let text = self.text == "" ? nil : self.text
         
-        // TODO: the DateInterval and location radius are hardcoded for now
-        //       this will change soon in coming BUD- stories ;)
-        return (text, nil, 20000)
+        let date = nextDateRange ?? (lastSearchParams.dateMin, lastSearchParams.dateMax)
+        let location = nextLocationRange ?? lastSearchParams.maxMilesAway
+        
+        return (text, date.0, date.1, location)
     }
     
     func fetchAndLoadActivities() {
+        // If there is a timer, invalidate it! We're searching now.
+        searchTimer?.invalidate()
+
         let myParams = getSearchParams()
         
         if lastSearchParams == myParams {
@@ -159,12 +282,16 @@ class FilterSearchBar : UISearchBar, UISearchBarDelegate {
         // Store request params #NoRaceConditions
         self.lastSearchParams = myParams
         
+        let start = DateRangeSliderDelegate.instance.getSliderDate(sliderValue: CGFloat(myParams.dateMin))
+        let end = DateRangeSliderDelegate.instance.getSliderDate(sliderValue: CGFloat(myParams.dateMax))
+        let distance = Int(FilterSearchBar.metersPerMile * myParams.maxMilesAway)
+        
         // Load data from algolia!
         api.searchActivities(withText: myParams.filterText,
                              matchingAnyTopicOf: displayDelegate?.getTopics(),
-                             startingAt: myParams.when?.start,
-                             endingAt: myParams.when?.end,
-                             upToDisatnce: myParams.maxMetersAway) {
+                             startingAt: start,
+                             endingAt: end,
+                             upToDisatnce: distance) {
             (activities: [ActivityId], err: Error?) in
             
             // Cancel if we've made a new request #NoRaceConditions

--- a/Buddies/CreateActivity/CreateActivityVC.swift
+++ b/Buddies/CreateActivity/CreateActivityVC.swift
@@ -13,7 +13,7 @@ import Firebase
 //https://stackoverflow.com/questions/33380711/how-to-implement-auto-complete-for-address-using-apple-map-kit
 //https://www.thorntech.com/2016/01/how-to-search-for-location-using-apples-mapkit/
 //https://stackoverflow.com/questions/39946100/search-for-address-using-swift
-class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDelegate, RangeSeekSliderDelegate{
+class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDelegate {
     
     @IBOutlet weak var dateSlider: RangeSeekSlider!
     //MARK: - Variables/setup
@@ -83,8 +83,8 @@ class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDe
                 location: GeoPoint(latitude: chosenLocation.latitude,
                                    longitude: chosenLocation.longitude),
                 location_text: locationText,
-                start_time: getSliderDate(sliderValue: minSliderValue),
-                end_time: getSliderDate(sliderValue: maxSliderValue),
+                start_time: DateRangeSliderDelegate.instance.getSliderDate(sliderValue: dateSlider.selectedMinValue),
+                end_time: DateRangeSliderDelegate.instance.getSliderDate(sliderValue: dateSlider.selectedMaxValue),
                 topicIDs: topicIDs
             )
             dismiss(animated: true, completion: _dismissHook)
@@ -144,7 +144,7 @@ class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDe
         
         searchCompleter.queryFragment = ""
         
-        dateSlider.delegate = self
+        dateSlider.delegate = DateRangeSliderDelegate.instance
         dateSlider.tintColor = UIColor.lightGray
         
         descriptionTextView.delegate = self
@@ -252,70 +252,7 @@ class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDe
         ])
     }
     
-    func getSliderString(sliderValue: CGFloat) -> String
-    {
-        switch sliderValue {
-        case 1:
-            return "Today"
-        case 2:
-            return "Tomorrow"
-        case 3:
-            return "Next 3 Days"
-        case 4:
-            return "Next Week"
-        case 5:
-            return "Next 2 Weeks"
-        case 6:
-            return "Next Month"
-        default:
-            return "Today"
-        }
-
-    }
- 
-    
-    func getSliderDate(sliderValue: CGFloat) -> Date {
-        
-        var dateComponent = DateComponents()
-        
-        switch sliderValue {
-        case 1:
-            dateComponent.day = 0
-        case 2:
-            dateComponent.day = 1
-        case 3:
-            dateComponent.day = 3
-        case 4:
-            dateComponent.day = 7
-        case 5:
-            dateComponent.day = 14
-        case 6:
-            dateComponent.day = 30
-        default:
-            dateComponent.day = 0
-        }
-        
-        return Calendar.current.date(byAdding: dateComponent, to: Date())!
-        
-    }
-    
-    
-    func rangeSeekSlider(_ slider: RangeSeekSlider, stringForMinValue minValue: CGFloat) -> String? {
-        
-        minSliderValue = minValue
-        return getSliderString(sliderValue: minValue)
-        
-    }
-    
-    func rangeSeekSlider(_ slider: RangeSeekSlider, stringForMaxValue maxValue: CGFloat) -> String? {
-
-        maxSliderValue = maxValue
-        return getSliderString(sliderValue: maxValue)
-        
-    }
-    
-    func setChosenLocation(location:MapItemSearchResult)
-    {
+    func setChosenLocation(location:MapItemSearchResult) {
         let searchRequest = MKLocalSearch.Request(completion: location.mapData!)
         let search = MKLocalSearch(request: searchRequest)
         
@@ -323,12 +260,12 @@ class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDe
             self.chosenLocation = response?.mapItems[0].placemark.coordinate ?? CLLocationCoordinate2D()
         }
         
-         self.locationText = location.title
+        self.locationText = location.title
     }
+
     
     //MARK: - Location field
-    func configureSearchTextField()
-    {
+    func configureSearchTextField() {
         
         locationField.theme.cellHeight = 50
         locationField.maxNumberOfResults = 10

--- a/Buddies/CreateActivity/CreateActivityVC.swift
+++ b/Buddies/CreateActivity/CreateActivityVC.swift
@@ -83,8 +83,8 @@ class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDe
                 location: GeoPoint(latitude: chosenLocation.latitude,
                                    longitude: chosenLocation.longitude),
                 location_text: locationText,
-                start_time: DateRangeSliderDelegate.instance.getSliderDate(sliderValue: dateSlider.selectedMinValue),
-                end_time: DateRangeSliderDelegate.instance.getSliderDate(sliderValue: dateSlider.selectedMaxValue),
+                start_time: DateRangeSliderDelegate.getDate(sliderIndex: Int(dateSlider.selectedMinValue)),
+                end_time: DateRangeSliderDelegate.getDate(sliderIndex: Int(dateSlider.selectedMaxValue)),
                 topicIDs: topicIDs
             )
             dismiss(animated: true, completion: _dismissHook)

--- a/Buddies/Discover/DiscoverVC.swift
+++ b/Buddies/Discover/DiscoverVC.swift
@@ -1,5 +1,5 @@
 //
-//  ExlporeVC.swift
+//  DiscoverVC.swift
 //  Buddies
 //
 //  Created by Jake Thurman on 2/2/19.
@@ -7,30 +7,36 @@
 //
 
 import UIKit
+import Firebase
 
-class DiscoverVC: UITableViewController {
+class DiscoverVC : ActivityTableVC {
+    @IBOutlet weak var searchBar: FilterSearchBar!
     
-    var fab: FAB!
+    var user: User? { didSet { self.searchBar.fetchAndLoadActivities() } }
+    var cancelUserListener: Canceler?
     
     override func viewDidLoad() {
-        super.viewDidLoad()
+        self.setupHideKeyboardOnTap()
         
-        // We need to store a local so that the
-        //  instance isn't deallocated along with
-        //  the event handler!
-        fab = FAB(for: self)
-        fab.renderCreateActivityFab()
+        guard let userId = Auth.auth().currentUser?.uid else { return }
+        cancelUserListener = DataAccessor.instance.useUser(id: userId) { user in
+            self.user = user
+        }
+        
+        searchBar.displayDelegate = self
+        
+        super.viewDidLoad()
     }
     
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+    deinit {
+        cancelUserListener?()
     }
-    */
-
+    
+    override func getTopics() -> [String] {
+        return user?.favoriteTopics ?? []
+    }
+    
+    override func fetchAndLoadActivities() {
+        searchBar.fetchAndLoadActivities()
+    }
 }

--- a/Buddies/Extensions/UIView.swift
+++ b/Buddies/Extensions/UIView.swift
@@ -19,12 +19,14 @@ extension UIView {
             return
         }
         
+        let guide = superview.safeAreaLayoutGuide
+        
         self.translatesAutoresizingMaskIntoConstraints = false
-        self.topAnchor.constraint(equalTo: superview.topAnchor, constant: 0).isActive = true
-        self.leadingAnchor.constraint(equalTo: superview.leadingAnchor, constant: 0).isActive = true
-        self.trailingAnchor.constraint(equalTo: superview.trailingAnchor, constant: 0).isActive = true
+        self.topAnchor.constraint(equalTo: guide.topAnchor, constant: 0).isActive = true
+        self.leadingAnchor.constraint(equalTo: guide.leadingAnchor, constant: 0).isActive = true
+        self.trailingAnchor.constraint(equalTo: guide.trailingAnchor, constant: 0).isActive = true
         if (shouldConstraintBottom) {
-            self.bottomAnchor.constraint(equalTo: superview.bottomAnchor, constant: 0).isActive = true
+            self.bottomAnchor.constraint(equalTo: guide.bottomAnchor, constant: 0).isActive = true
         }
     }
     

--- a/Buddies/Storyboards/CreateActivity.storyboard
+++ b/Buddies/Storyboards/CreateActivity.storyboard
@@ -119,12 +119,10 @@
                                                         <userDefinedRuntimeAttribute type="color" keyPath="handleColor">
                                                             <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                         </userDefinedRuntimeAttribute>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="initialColor">
-                                                            <color key="value" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="nil" keyPath="initialColor"/>
                                                         <userDefinedRuntimeAttribute type="boolean" keyPath="disableRange" value="NO"/>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="handleBorderWidth">
-                                                            <real key="value" value="2"/>
+                                                            <integer key="value" value="2"/>
                                                         </userDefinedRuntimeAttribute>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="labelPadding">
                                                             <real key="value" value="2"/>

--- a/Buddies/Storyboards/Main.storyboard
+++ b/Buddies/Storyboards/Main.storyboard
@@ -93,14 +93,135 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <searchBar key="tableHeaderView" contentMode="redraw" searchBarStyle="minimal" text="" id="KIf-Nm-CEC" customClass="FilterSearchBar" customModule="Buddies" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
+                            <textInputTraits key="textInputTraits"/>
+                        </searchBar>
                         <prototypes>
-                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="foo" id="FZc-FI-tng">
-                                <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="activityCell" rowHeight="110" id="LUN-tj-iX8" customClass="ActivityCell" customModule="Buddies" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="84" width="375" height="110"/>
                                 <autoresizingMask key="autoresizingMask"/>
-                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="FZc-FI-tng" id="qDP-Oz-tgH">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LUN-tj-iX8" id="zmR-Ii-9ix">
+                                    <rect key="frame" x="0.0" y="0.0" width="341" height="109.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Activity Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EiY-au-VSv">
+                                            <rect key="frame" x="20" y="5" width="95" height="21"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Next Week" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3w9-Zd-TJW">
+                                            <rect key="frame" x="222" y="11.5" width="119" height="14.5"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="119" id="i0n-D9-FlC"/>
+                                            </constraints>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dQv-IU-hmU">
+                                            <rect key="frame" x="20" y="31" width="321" height="40"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="40" id="1z6-77-K8y"/>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="jbR-dP-FZo"/>
+                                            </constraints>
+                                            <string key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et massa eget augue malesuada ullamcorper. Duis suscipit lorem velit, et venenatis est vehicula id. Integer et venenatis dolor. Proin quam ante, posuere non viverra in, facilisis in tortor. </string>
+                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="right" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zon-E2-gN6">
+                                            <rect key="frame" x="287.5" y="75" width="48.5" height="24.5"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eOI-zk-s7v">
+                                            <rect key="frame" x="119" y="79.5" width="14" height="20"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                            <nil key="textColor"/>
+                                            <nil key="highlightedColor"/>
+                                        </label>
+                                        <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7d6-SR-dRU">
+                                            <rect key="frame" x="20" y="74.5" width="25" height="25"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="25" id="hG5-Yo-frD"/>
+                                                <constraint firstAttribute="height" constant="25" id="vpA-kh-78B"/>
+                                            </constraints>
+                                            <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <state key="normal">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="goToUserProfile:" destination="LUN-tj-iX8" eventType="touchUpInside" id="h9t-WD-tS4"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cwt-Gc-nr3">
+                                            <rect key="frame" x="53" y="74.5" width="25" height="25"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="height" constant="25" id="Bjm-dy-6St"/>
+                                                <constraint firstAttribute="width" constant="25" id="YN8-eG-mng"/>
+                                            </constraints>
+                                            <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <state key="normal">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="goToUserProfile:" destination="LUN-tj-iX8" eventType="touchUpInside" id="iBK-sI-Yl6"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="31h-P0-5rM">
+                                            <rect key="frame" x="86" y="74.5" width="25" height="25"/>
+                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="25" id="ig8-j7-nRE"/>
+                                                <constraint firstAttribute="height" constant="25" id="xhI-Hn-PAs"/>
+                                            </constraints>
+                                            <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            <state key="normal">
+                                                <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="goToUserProfile:" destination="LUN-tj-iX8" eventType="touchUpInside" id="PXh-OA-F82"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="zon-E2-gN6" firstAttribute="top" secondItem="dQv-IU-hmU" secondAttribute="bottom" constant="4" id="1JE-N0-fXD"/>
+                                        <constraint firstAttribute="bottom" secondItem="eOI-zk-s7v" secondAttribute="bottom" constant="10" id="4yv-BI-XLg"/>
+                                        <constraint firstItem="31h-P0-5rM" firstAttribute="leading" secondItem="cwt-Gc-nr3" secondAttribute="trailing" constant="8" id="BFY-g8-GDt"/>
+                                        <constraint firstAttribute="bottom" secondItem="zon-E2-gN6" secondAttribute="bottom" constant="10" id="FLQ-v6-cje"/>
+                                        <constraint firstItem="eOI-zk-s7v" firstAttribute="top" secondItem="dQv-IU-hmU" secondAttribute="bottom" constant="8.5" id="MsT-d5-7r6"/>
+                                        <constraint firstItem="dQv-IU-hmU" firstAttribute="top" secondItem="3w9-Zd-TJW" secondAttribute="bottom" constant="5" id="OSA-wG-E6P"/>
+                                        <constraint firstItem="dQv-IU-hmU" firstAttribute="leading" secondItem="zmR-Ii-9ix" secondAttribute="leading" constant="20" id="RNS-wl-9IE"/>
+                                        <constraint firstItem="7d6-SR-dRU" firstAttribute="leading" secondItem="zmR-Ii-9ix" secondAttribute="leading" constant="20" id="Rfy-ER-RZT"/>
+                                        <constraint firstItem="cwt-Gc-nr3" firstAttribute="leading" secondItem="7d6-SR-dRU" secondAttribute="trailing" constant="8" id="VPe-tS-bMe"/>
+                                        <constraint firstItem="dQv-IU-hmU" firstAttribute="top" secondItem="EiY-au-VSv" secondAttribute="bottom" constant="5" id="d9q-xN-h8K"/>
+                                        <constraint firstItem="EiY-au-VSv" firstAttribute="leading" secondItem="zmR-Ii-9ix" secondAttribute="leading" constant="20" id="hoh-92-rLx"/>
+                                        <constraint firstItem="eOI-zk-s7v" firstAttribute="leading" secondItem="31h-P0-5rM" secondAttribute="trailing" constant="8" id="izO-6R-xg7"/>
+                                        <constraint firstAttribute="bottom" secondItem="31h-P0-5rM" secondAttribute="bottom" constant="10" id="j2W-hv-4gz"/>
+                                        <constraint firstAttribute="bottom" secondItem="7d6-SR-dRU" secondAttribute="bottom" constant="10" id="m7i-24-BXp"/>
+                                        <constraint firstAttribute="trailing" secondItem="dQv-IU-hmU" secondAttribute="trailing" id="nfQ-uG-lcz"/>
+                                        <constraint firstAttribute="bottom" secondItem="cwt-Gc-nr3" secondAttribute="bottom" constant="10" id="osA-9X-kEr"/>
+                                        <constraint firstItem="EiY-au-VSv" firstAttribute="top" secondItem="zmR-Ii-9ix" secondAttribute="top" constant="5" id="yTE-MO-9GA"/>
+                                        <constraint firstAttribute="trailing" secondItem="3w9-Zd-TJW" secondAttribute="trailing" id="zH0-kr-wQ0"/>
+                                        <constraint firstAttribute="trailing" secondItem="zon-E2-gN6" secondAttribute="trailing" constant="5" id="zUo-km-1WQ"/>
+                                    </constraints>
                                 </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="dateLabel" destination="3w9-Zd-TJW" id="xmb-8a-OZX"/>
+                                    <outlet property="descriptionLabel" destination="dQv-IU-hmU" id="Ogg-lx-Kdu"/>
+                                    <outlet property="extraPicturesLabel" destination="eOI-zk-s7v" id="ezO-N1-ShH"/>
+                                    <outlet property="locationLabel" destination="zon-E2-gN6" id="FoR-wW-FWq"/>
+                                    <outlet property="titleLabel" destination="EiY-au-VSv" id="5IJ-ww-GgW"/>
+                                    <outletCollection property="memberPics" destination="7d6-SR-dRU" collectionClass="NSMutableArray" id="2Bh-gS-mnU"/>
+                                    <outletCollection property="memberPics" destination="cwt-Gc-nr3" collectionClass="NSMutableArray" id="gIC-J3-Bpo"/>
+                                    <outletCollection property="memberPics" destination="31h-P0-5rM" collectionClass="NSMutableArray" id="21o-h8-yOi"/>
+                                </connections>
                             </tableViewCell>
                         </prototypes>
                         <connections>
@@ -109,10 +230,13 @@
                         </connections>
                     </tableView>
                     <tabBarItem key="tabBarItem" title="Discover" image="Discover" id="SFH-LK-a8R"/>
+                    <connections>
+                        <outlet property="searchBar" destination="KIf-Nm-CEC" id="25B-mz-YFe"/>
+                    </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Agp-Yw-O7X" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="564" y="-922"/>
+            <point key="canvasLocation" x="564" y="-924"/>
         </scene>
         <!--viewTopics-->
         <scene sceneID="QYt-tQ-Ph0">

--- a/BuddiesTests/Controls/FilterSearchBarTests.swift
+++ b/BuddiesTests/Controls/FilterSearchBarTests.swift
@@ -30,16 +30,13 @@ class FilterSearchBarTests: XCTestCase {
         
         parent = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
         
-        let container = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
-        parent.addSubview(container)
-        
         bar = FilterSearchBar(frame: parent.frame)
         bar.api = search
         
         deli = TestFilterSearchBarDelegate()
         bar.displayDelegate = deli
         
-        container.addSubview(bar)
+        parent.addSubview(bar)
     }
 
     func testFilterMenuToggling() {

--- a/BuddiesTests/Controls/FilterSearchBarTests.swift
+++ b/BuddiesTests/Controls/FilterSearchBarTests.swift
@@ -30,16 +30,19 @@ class FilterSearchBarTests: XCTestCase {
         
         parent = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
         
+        let container = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
+        parent.addSubview(container)
+        
         bar = FilterSearchBar(frame: parent.frame)
         bar.api = search
         
         deli = TestFilterSearchBarDelegate()
         bar.displayDelegate = deli
         
-        parent.addSubview(bar)
+        container.addSubview(bar)
     }
 
-    func testExample() {
+    func testFilterMenuToggling() {
         XCTAssert(parent.subviews.count == 1)
         
         // Toggle the menu ON
@@ -48,7 +51,7 @@ class FilterSearchBarTests: XCTestCase {
         XCTAssert(parent.subviews.count == 2)
         
         // Toggle the menu OFF
-        bar.onFilterTapped()
+        bar.closeFilterMenu()
         
         XCTAssert(parent.subviews.count == 1)
     }
@@ -59,16 +62,6 @@ class FilterSearchBarTests: XCTestCase {
         deli.onDisplay = { exp.fulfill() }
         
         bar.searchBarSearchButtonClicked(bar)
-        
-        self.waitForExpectations(timeout: 1)
-    }
-    
-    func testSearchBarCancelButtonClicked() {
-        let exp = self.expectation(description: "search triggered")
-        
-        deli.onDisplay = { exp.fulfill() }
-        
-        bar.searchBarCancelButtonClicked(bar)
         
         self.waitForExpectations(timeout: 1)
     }
@@ -85,5 +78,33 @@ class FilterSearchBarTests: XCTestCase {
         XCTAssertNotNil(bar.searchTimer)
         
         self.waitForExpectations(timeout: 2)
+    }
+    
+    func testSaveFilterMenu() {
+        let exp = self.expectation(description: "search triggered")
+        deli.onDisplay = { exp.fulfill() }
+        
+        XCTAssertNil(bar.filterMenu)
+
+        // Open the filter menu
+        bar.onFilterTapped()
+        
+        XCTAssertNotNil(bar.filterMenu)
+        
+        // Setup values to save
+        bar.filterMenu?.dateSlider.selectedMinValue = 1
+        bar.filterMenu?.dateSlider.selectedMaxValue = 3
+        bar.filterMenu?.locationRangeSlider.selectedMaxValue = 20
+        
+        // Save it!
+        bar.saveFilterMenu()
+        
+        XCTAssertNil(bar.filterMenu)
+        
+        self.waitForExpectations(timeout: 2)
+        
+        XCTAssert(bar.lastSearchParams.dateMin == 1)
+        XCTAssert(bar.lastSearchParams.dateMax == 3)
+        XCTAssert(bar.lastSearchParams.maxMilesAway == 20)
     }
 }


### PR DESCRIPTION
**Note:** The following is not included, this is a separate story. (The filter sliders will persist only until you leave the view)

> The "distance" and "date" filters in the search component should be persistent across all instances of the search component

To Test:
1. Navigate to Topics Tab
2. Select any Topic
3. Tap the "Filter" button on search bar
4. Drag sliders, and observe changes in search results after tapping "Filter"