### PR TITLE
Bug fixes 1

### DIFF
--- a/Buddies/Activities/ActivityTableVC.swift
+++ b/Buddies/Activities/ActivityTableVC.swift
@@ -149,8 +149,17 @@ class ActivityTableVC: UITableViewController, FilterSearchBarDelegate {
         cell.locationLabel.text = activity.locationText
         let dateRange = DateInterval(start: activity.startTime.dateValue(),
                                      end: activity.endTime.dateValue())
+    
         
-        cell.dateLabel.text = dateRange.rangePhrase(relativeTo: Date()).capitalized
+        let pixelsPerChar: CGFloat = 10.0
+        
+        let charsFitInCell = Int(cell.frame.width/pixelsPerChar)
+        
+        let locStrLength = max(15, charsFitInCell - activity.title.count)
+        
+        let locStr = dateRange.rangePhrase(relativeTo: Date(), tryShorteningIfLongerThan: locStrLength)
+        
+        cell.dateLabel.text = locStr.capitalized
 
         let activityUserImages = activity.members.compactMap { users[$0]?.image }
         

--- a/Buddies/Activities/View Activity/ActivityDescription.xib
+++ b/Buddies/Activities/View Activity/ActivityDescription.xib
@@ -54,7 +54,10 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="|" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nBe-TR-yw0">
-                            <rect key="frame" x="105" y="54" width="7" height="26"/>
+                            <rect key="frame" x="105" y="54" width="5" height="26"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="5" id="6hv-nv-bHg"/>
+                            </constraints>
                             <fontDescription key="fontDescription" type="system" weight="thin" pointSize="21"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -117,7 +120,10 @@
                             </connections>
                         </button>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Next week" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MBj-Rw-ymJ">
-                            <rect key="frame" x="117" y="57" width="80" height="21"/>
+                            <rect key="frame" x="115" y="57" width="100" height="21"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="100" id="em0-oS-WUk"/>
+                            </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -155,7 +161,7 @@
                         <constraint firstItem="ljP-m1-Bup" firstAttribute="leading" secondItem="dD2-Xh-Hu7" secondAttribute="leading" constant="20" id="6GJ-SP-Ss8"/>
                         <constraint firstItem="DbE-YH-bXB" firstAttribute="centerX" secondItem="6Fx-Cv-PlK" secondAttribute="centerX" id="6mb-TN-SWf"/>
                         <constraint firstItem="Bum-mZ-tD9" firstAttribute="top" secondItem="OfB-xg-0le" secondAttribute="bottom" constant="20" id="7Lm-W1-zqu"/>
-                        <constraint firstItem="nBe-TR-yw0" firstAttribute="leading" secondItem="OfB-xg-0le" secondAttribute="trailing" constant="5" id="9px-YI-8bO"/>
+                        <constraint firstItem="nBe-TR-yw0" firstAttribute="leading" secondItem="OfB-xg-0le" secondAttribute="trailing" constant="5" identifier="locToSeperator" id="9px-YI-8bO"/>
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="bottom" secondItem="iPS-y9-NQ4" secondAttribute="bottom" constant="20" id="9wo-la-xc2"/>
                         <constraint firstItem="Bum-mZ-tD9" firstAttribute="leading" secondItem="dD2-Xh-Hu7" secondAttribute="leading" constant="20" id="HQH-OE-Erf"/>
                         <constraint firstItem="iPS-y9-NQ4" firstAttribute="leading" secondItem="dD2-Xh-Hu7" secondAttribute="leading" constant="20" id="JDA-t3-chW"/>
@@ -165,13 +171,14 @@
                         <constraint firstItem="1BD-Ph-UYj" firstAttribute="leading" secondItem="dD2-Xh-Hu7" secondAttribute="leading" constant="20" id="Skz-Lc-rD4"/>
                         <constraint firstItem="nBe-TR-yw0" firstAttribute="top" secondItem="1BD-Ph-UYj" secondAttribute="bottom" constant="2" id="TNR-2l-AjY"/>
                         <constraint firstItem="ljP-m1-Bup" firstAttribute="top" secondItem="Bum-mZ-tD9" secondAttribute="bottom" constant="30" id="Xd3-k2-bg5"/>
+                        <constraint firstItem="dD2-Xh-Hu7" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MBj-Rw-ymJ" secondAttribute="trailing" constant="10" id="ZbE-o2-78g"/>
                         <constraint firstItem="OfB-xg-0le" firstAttribute="top" secondItem="1BD-Ph-UYj" secondAttribute="bottom" constant="5" id="dJc-HU-ubH"/>
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="bottom" secondItem="uBp-lP-0wh" secondAttribute="bottom" constant="100" id="e3L-g8-fXo"/>
                         <constraint firstItem="oYt-RJ-04X" firstAttribute="top" secondItem="ljP-m1-Bup" secondAttribute="bottom" constant="-13" id="eOT-VY-jaP"/>
                         <constraint firstItem="OfB-xg-0le" firstAttribute="leading" secondItem="dD2-Xh-Hu7" secondAttribute="leading" constant="20" id="eZx-Sd-iJr"/>
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="trailing" secondItem="ljP-m1-Bup" secondAttribute="trailing" constant="20" id="fbS-s7-pCy"/>
                         <constraint firstAttribute="trailing" secondItem="Bum-mZ-tD9" secondAttribute="trailing" constant="15" id="jHL-ba-naW"/>
-                        <constraint firstItem="MBj-Rw-ymJ" firstAttribute="leading" secondItem="nBe-TR-yw0" secondAttribute="trailing" constant="5" id="kTN-iB-GIr"/>
+                        <constraint firstItem="MBj-Rw-ymJ" firstAttribute="leading" secondItem="nBe-TR-yw0" secondAttribute="trailing" constant="5" identifier="seperatorToDate" id="kTN-iB-GIr"/>
                         <constraint firstItem="MBj-Rw-ymJ" firstAttribute="top" secondItem="1BD-Ph-UYj" secondAttribute="bottom" constant="5" id="mUh-PS-aJq"/>
                         <constraint firstItem="Khl-NW-sKH" firstAttribute="centerX" secondItem="6Fx-Cv-PlK" secondAttribute="centerX" id="mrR-Eo-nfC"/>
                         <constraint firstItem="Khl-NW-sKH" firstAttribute="top" relation="greaterThanOrEqual" secondItem="uBp-lP-0wh" secondAttribute="bottom" constant="5" id="ntE-Iv-sSk"/>

--- a/Buddies/Storyboards/PickTopics.storyboard
+++ b/Buddies/Storyboards/PickTopics.storyboard
@@ -105,7 +105,6 @@
                     </collectionView>
                     <navigationItem key="navigationItem" title="Pick Topics" id="HAC-sO-DYs">
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="TY4-1T-d5C">
-                            <color key="tintColor" red="1" green="0.14913141730000001" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <connections>
                                 <action selector="goBack" destination="Z8X-gW-KBb" id="KoK-Fu-Sr2"/>
                                 <segue destination="IUw-Tu-rrw" kind="unwind" unwindAction="unwindCancelPickTopicsWithSender:" id="7Mp-MI-OIG"/>

--- a/Buddies/Storyboards/Topics.storyboard
+++ b/Buddies/Storyboards/Topics.storyboard
@@ -139,10 +139,10 @@
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Next Week" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4qQ-bJ-6FM">
-                                            <rect key="frame" x="222" y="11.5" width="119" height="14.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tmrw - Next Mon" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4qQ-bJ-6FM">
+                                            <rect key="frame" x="236" y="11" width="105" height="15"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" constant="119" id="5T5-CO-txg"/>
+                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="105" id="GBr-z8-JPq"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
@@ -152,7 +152,6 @@
                                             <rect key="frame" x="20" y="31" width="321" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="h7S-nt-A9g"/>
-                                                <constraint firstAttribute="height" constant="40" id="paS-a8-G5q"/>
                                             </constraints>
                                             <string key="text">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse et massa eget augue malesuada ullamcorper. Duis suscipit lorem velit, et venenatis est vehicula id. Integer et venenatis dolor. Proin quam ante, posuere non viverra in, facilisis in tortor. </string>
                                             <fontDescription key="fontDescription" type="system" pointSize="11"/>
@@ -227,6 +226,7 @@
                                         <constraint firstAttribute="trailing" secondItem="dQP-6N-2Y4" secondAttribute="trailing" id="EaI-HS-mBc"/>
                                         <constraint firstItem="rgD-aX-zsY" firstAttribute="leading" secondItem="oCq-dl-qhy" secondAttribute="leading" constant="20" id="Vzy-el-aob"/>
                                         <constraint firstAttribute="bottom" secondItem="KuL-7h-pqY" secondAttribute="bottom" constant="10" id="WSM-By-bDp"/>
+                                        <constraint firstItem="4qQ-bJ-6FM" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rgD-aX-zsY" secondAttribute="trailing" constant="5" id="ZQf-UI-Fa6"/>
                                         <constraint firstAttribute="bottom" secondItem="Qve-HN-jk6" secondAttribute="bottom" constant="10" id="bvN-Dm-9V4"/>
                                         <constraint firstItem="dQP-6N-2Y4" firstAttribute="top" secondItem="rgD-aX-zsY" secondAttribute="bottom" constant="5" id="cee-D2-djz"/>
                                         <constraint firstAttribute="trailing" secondItem="4qQ-bJ-6FM" secondAttribute="trailing" id="eE7-x7-DaG"/>

--- a/Buddies/Storyboards/Topics.storyboard
+++ b/Buddies/Storyboards/Topics.storyboard
@@ -166,6 +166,9 @@
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rKW-B9-aQY">
                                             <rect key="frame" x="119" y="79.5" width="14" height="20"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="14" id="L5l-xK-deB"/>
+                                            </constraints>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -224,6 +227,7 @@
                                         <constraint firstItem="6nR-gN-5El" firstAttribute="top" secondItem="dQP-6N-2Y4" secondAttribute="bottom" constant="4" id="BHQ-IG-2Xl"/>
                                         <constraint firstItem="Qve-HN-jk6" firstAttribute="leading" secondItem="KuL-7h-pqY" secondAttribute="trailing" constant="8" id="Dyw-Gq-5o4"/>
                                         <constraint firstAttribute="trailing" secondItem="dQP-6N-2Y4" secondAttribute="trailing" id="EaI-HS-mBc"/>
+                                        <constraint firstItem="6nR-gN-5El" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rKW-B9-aQY" secondAttribute="trailing" constant="10" id="LCv-I1-5XI"/>
                                         <constraint firstItem="rgD-aX-zsY" firstAttribute="leading" secondItem="oCq-dl-qhy" secondAttribute="leading" constant="20" id="Vzy-el-aob"/>
                                         <constraint firstAttribute="bottom" secondItem="KuL-7h-pqY" secondAttribute="bottom" constant="10" id="WSM-By-bDp"/>
                                         <constraint firstItem="4qQ-bJ-6FM" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rgD-aX-zsY" secondAttribute="trailing" constant="5" id="ZQf-UI-Fa6"/>

--- a/BuddiesTests/Extensions/DateIntervalTests.swift
+++ b/BuddiesTests/Extensions/DateIntervalTests.swift
@@ -90,12 +90,22 @@ class DateIntervalTests: XCTestCase {
         let friThruSat = DateInterval(start: friday, end: friday + 1.days)
         
         XCTAssert(friThruSat.shortRangePhrase(relativeTo: wednesday)
-            == "Friday through Saturday")
+            == "Friday - Saturday")
         
         let monThruThurs = DateInterval(start: monday, end: monday.dateAt(.nextWeekday(.thursday)))
         
         XCTAssert(monThruThurs.shortRangePhrase(relativeTo: saturday)
-            == "Monday through Thursday")
+            == "Monday - Thursday")
+        
+        let friThruSatShort = DateInterval(start: friday, end: friday + 1.days)
+        
+        XCTAssert(friThruSatShort.shortRangePhrase(relativeTo: wednesday, dayFormat: .short)
+            == "Fri - Sat")
+        
+        let monThruThursShort = DateInterval(start: monday, end: monday.dateAt(.nextWeekday(.thursday)))
+        
+        XCTAssert(monThruThursShort.shortRangePhrase(relativeTo: saturday, dayFormat: .short)
+            == "Mon - Thu")
     }
     
     func testShortRangeString_toRelative(){
@@ -103,11 +113,14 @@ class DateIntervalTests: XCTestCase {
         - 10.days)
         
         XCTAssert(tenDaysAgo.shortRangePhrase(relativeTo: now) == "a week ago")
+        XCTAssert(tenDaysAgo.shortRangePhrase(relativeTo: now, dayFormat: .short) == "a week ago")
         
         let tenDaysAhead = DateInterval(start: now + 10.days, end: now
             + 20.days)
 
         XCTAssert(tenDaysAhead.shortRangePhrase(relativeTo: now) == "in a week")
+        XCTAssert(tenDaysAhead.shortRangePhrase(relativeTo: now, dayFormat: .short) == "in a week")
+
     }
     
     func testWeekRangeString_Past(){
@@ -171,6 +184,10 @@ class DateIntervalTests: XCTestCase {
         XCTAssert(lastDec.monthRangePhrase(relativeTo: monday) == "last December")
 
         XCTAssert(nextOct.monthRangePhrase(relativeTo: monday) == "next October")
+        
+        XCTAssert(lastDec.monthRangePhrase(relativeTo: monday, monthFormat: .short) == "last Dec")
+        
+        XCTAssert(nextOct.monthRangePhrase(relativeTo: monday, monthFormat: .short) == "next Oct")
     }
     
     func testMonthRangeString_toRelative(){
@@ -190,36 +207,70 @@ class DateIntervalTests: XCTestCase {
         }
     }
     
-    func testGeneralRangeString_Short(){
+    func testGeneralRangeString_ShortDate_LongStr(){
         let shortGap = DateInterval(start: monday, duration: 3.days.timeInterval)
-        XCTAssert(shortGap.rangePhrase(relativeTo: monday) == shortGap.shortRangePhrase(relativeTo: monday))
+        XCTAssert(shortGap.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == shortGap.shortRangePhrase(relativeTo: monday, dayFormat: .default))
     }
 
-    func testGeneralRangeString_Weeks(){
+    func testGeneralRangeString_Weeks_LongStr(){
         let oneWeek = DateInterval(start: monday, duration: 1.weeks.timeInterval)
-        XCTAssert(oneWeek.rangePhrase(relativeTo: monday) == oneWeek.shortRangePhrase(relativeTo: monday))
+
+        XCTAssert(oneWeek.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == oneWeek.shortRangePhrase(relativeTo: monday, dayFormat: .default))
         
         let threeWeek = DateInterval(start: monday, duration: 3.weeks.timeInterval)
-        XCTAssert(threeWeek.rangePhrase(relativeTo: monday) == threeWeek.weekRangePhrase(relativeTo: monday))
+        XCTAssert(threeWeek.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == threeWeek.weekRangePhrase(relativeTo: monday))
 
         let fourWeek = DateInterval(start: monday, duration: 4.weeks.timeInterval)
-        XCTAssert(fourWeek.rangePhrase(relativeTo: monday) == fourWeek.monthRangePhrase(relativeTo: monday))
+        XCTAssert(fourWeek.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == fourWeek.monthRangePhrase(relativeTo: monday, monthFormat: .default))
     }
 
-    func testGeneralRangeString_Months(){
+    func testGeneralRangeString_Months_LongStr(){
         
         let oneMonth = DateInterval(start: monday, duration: 1.months.timeInterval)
-        XCTAssert(oneMonth.rangePhrase(relativeTo: monday) == oneMonth.monthRangePhrase(relativeTo: monday))
+        XCTAssert(oneMonth.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == oneMonth.monthRangePhrase(relativeTo: monday, monthFormat: .default))
 
         let twoMonth = DateInterval(start: monday, duration: 2.months.timeInterval)
-        XCTAssert(twoMonth.rangePhrase(relativeTo: monday) == twoMonth.monthRangePhrase(relativeTo: monday))
+        XCTAssert(twoMonth.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == twoMonth.monthRangePhrase(relativeTo: monday, monthFormat: .default))
         
         let threeMonth = DateInterval(start: monday, duration: 3.months.timeInterval)
-        XCTAssert(threeMonth.rangePhrase(relativeTo: monday) == threeMonth.monthRangePhrase(relativeTo: monday))
+        XCTAssert(threeMonth.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == threeMonth.monthRangePhrase(relativeTo: monday, monthFormat: .default))
     }
-    func testGeneralRangeString_Years(){
+    func testGeneralRangeString_Years_LongStr(){
         let huge = DateInterval(start: monday, duration: 3.years.timeInterval)
-        XCTAssert(huge.rangePhrase(relativeTo: monday) == "today through \(huge.end.calendarString(relativeTo: monday))")
+        XCTAssert(huge.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: Int.max) == "today - \(huge.end.calendarString(relativeTo: monday, dayFormat: .default))")
+    }
+    
+    func testGeneralRangeString_ShortDate_ShortStr(){
+        let shortGap = DateInterval(start: monday, duration: 3.days.timeInterval)
+        XCTAssert(shortGap.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == shortGap.shortRangePhrase(relativeTo: monday, dayFormat: .short))
+    }
+    
+    func testGeneralRangeString_Weeks_ShortStr(){
+        let oneWeek = DateInterval(start: monday, duration: 1.weeks.timeInterval)
+        
+        XCTAssert(oneWeek.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == oneWeek.shortRangePhrase(relativeTo: monday, dayFormat: .short))
+        
+        let threeWeek = DateInterval(start: monday, duration: 3.weeks.timeInterval)
+        XCTAssert(threeWeek.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == threeWeek.weekRangePhrase(relativeTo: monday))
+        
+        let fourWeek = DateInterval(start: monday, duration: 4.weeks.timeInterval)
+        XCTAssert(fourWeek.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == fourWeek.monthRangePhrase(relativeTo: monday, monthFormat: .short))
+    }
+    
+    func testGeneralRangeString_Months_ShortStr(){
+        
+        let oneMonth = DateInterval(start: monday, duration: 1.months.timeInterval)
+        XCTAssert(oneMonth.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == oneMonth.monthRangePhrase(relativeTo: monday, monthFormat: .short))
+        
+        let twoMonth = DateInterval(start: monday, duration: 2.months.timeInterval)
+        XCTAssert(twoMonth.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == twoMonth.monthRangePhrase(relativeTo: monday, monthFormat: .short))
+        
+        let threeMonth = DateInterval(start: monday, duration: 3.months.timeInterval)
+        XCTAssert(threeMonth.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == threeMonth.monthRangePhrase(relativeTo: monday, monthFormat: .short))
+    }
+    func testGeneralRangeString_Years_ShortStr(){
+        let huge = DateInterval(start: monday, duration: 3.years.timeInterval)
+        XCTAssert(huge.rangePhrase(relativeTo: monday, tryShorteningIfLongerThan: 0) == "today - \(huge.end.calendarString(relativeTo: monday, dayFormat: .short))")
     }
 
 }


### PR DESCRIPTION
Resolves #77 by simply making the cancel button in `Pick Topics` blue.

To test:
1. Is the cancel button in Pick Topics blue? Cool.

Resolves #73:
 * changing constraints
 * shortening date strings if the title is long
 * shorting date strings if the date string is long

To test:
1. Create some activities, especially ones dealing with the next few days 
   * Some with long titles, some with short titles
2. None of the date strings should have ellipses, and should not be truncated
3. Long titles can be truncated w/ ellipses 

<img width="354" alt="screen shot 2019-03-01 at 2 23 34 pm" src="https://user-images.githubusercontent.com/7787605/53665034-44b41b00-3c38-11e9-8d43-1d39283c1e89.png">
<img width="349" alt="screen shot 2019-03-01 at 2 21 41 pm" src="https://user-images.githubusercontent.com/7787605/53665035-454cb180-3c38-11e9-9b13-5f5d89c6990a.png">


Resolves #67:
* Adding some constraints

To test:
1. Create an activity with a long location string (you can modify it in Firebase console if that's easier)
2. All the photos in the Tableview should appear un-occluded 
3. The long title may have ellipses to the right
4. In the view activity screen, only the location should be truncated with ellipses 
<img width="339" alt="screen shot 2019-03-01 at 2 39 03 pm" src="https://user-images.githubusercontent.com/7787605/53664999-3403a500-3c38-11e9-93ca-20ecccb04a18.png">
Or not cut off, if the screen is big enough
<img width="367" alt="screen shot 2019-03-01 at 2 29 40 pm" src="https://user-images.githubusercontent.com/7787605/53665010-39f98600-3c38-11e9-85c6-cef9fb5b9047.png">

Test all these on at least two device sizes.  
