### PR TITLE
Leverage DataAccessor to fix login wait issues

### DIFF
--- a/Buddies/Onboarding/AuthHandler.swift
+++ b/Buddies/Onboarding/AuthHandler.swift
@@ -21,12 +21,6 @@ class AuthHandler {
         self.notifications = NotificationService()
     }
     
-    func isLoggedIn() -> Bool {
-        return auth.currentUser != nil
-    }
-    
-
-    
     func saveFacebookAccessTokenToFirestore(
         facebookAccessToken: String,
         user: UserInfo? = Auth.auth().currentUser,

--- a/Buddies/Onboarding/LoginExistingVC.swift
+++ b/Buddies/Onboarding/LoginExistingVC.swift
@@ -49,25 +49,17 @@ class LoginExistingVC: LoginBase {
             email: email,
             password: password,
             onError: { msg in self.showMessagePrompt(msg) },
-            onSuccess: { user in self.handleOnLogIn(uid: user.uid) }
+            onSuccess: { _ in /* Navigation to main page is
+                                 handled by AppDelegate */ }
         )
-    }
-    
-    func handleOnLogIn(uid: String,
-                       app: AppDelegate? = UIApplication.shared.delegate as? AppDelegate) {
-        guard let app = app else {
-            print("no app given :(")
-            return
-        }
-        
-        app.tryLoadMainPage { callback in app.getHasUserDoc(callback: callback) }
     }
     
     @IBAction func facebookLogin() {
         getAuthHandler().logInWithFacebook(
             ref: self,
             onError: { msg in self.showMessagePrompt(msg) },
-            onSuccess: { user in self.handleOnLogIn(uid: user.uid) }
+            onSuccess: { _ in /* Navigation to main page is
+                                 handled by AppDelegate */ }
         )
     }
     

--- a/Buddies/Onboarding/SignUpInfoVC.swift
+++ b/Buddies/Onboarding/SignUpInfoVC.swift
@@ -180,7 +180,7 @@ class SignUpInfoVC: LoginBase, UIImagePickerControllerDelegate, UINavigationCont
     }
     
     func fillDataModel(user: UserInfo? = Auth.auth().currentUser,
-                       collection: CollectionReference = Firestore.firestore().collection("accounts")){
+                       collection: CollectionReference = DataAccessor.instance.accountCollection){
         
         if let UID = user?.uid {
             let favTopics: [String] = []
@@ -262,7 +262,9 @@ class SignUpInfoVC: LoginBase, UIImagePickerControllerDelegate, UINavigationCont
         else {
             saveBioToFirestore(bio: bioText.text)
             fillDataModel()
-            BuddiesStoryboard.Main.goTo()
+            
+            /* navigation to main storyboard
+               is handled by AppDelegate */
         }
     }
 }

--- a/Buddies/Profile/DeleteAccountVC.swift
+++ b/Buddies/Profile/DeleteAccountVC.swift
@@ -63,9 +63,7 @@ class DeleteAccountVC: LoginBase {
                         
                         //sign out user after deleting their account
                         let auth = AuthHandler(auth: Auth.auth())
-                        auth.signOut(onError: self.showMessagePrompt) {
-                            BuddiesStoryboard.Login.goTo()
-                        }
+                        auth.signOut(onError: self.showMessagePrompt) {/*success*/}
                     }
                 }
             }

--- a/Buddies/Profile/SettingsVC.swift
+++ b/Buddies/Profile/SettingsVC.swift
@@ -28,8 +28,7 @@ class SettingsVC: UITableViewController {
         stopListeningToUser?()
     }
     
-    func renderView(uid: String = Auth.auth().currentUser!.uid,
-                    dataAccess: DataAccessor = DataAccessor.instance) {
+    func renderView(dataAccess: DataAccessor = DataAccessor.instance) {
         var isFirstRender = true
         
         self.stopListeningToUser = dataAccess.useLoggedInUser { user in
@@ -98,9 +97,7 @@ class SettingsVC: UITableViewController {
     
     @IBAction func signOut(_ sender: Any) {
         let auth = AuthHandler(auth: Auth.auth())
-        auth.signOut(onError: showMessagePrompt) {
-            BuddiesStoryboard.Login.goTo()
-        }
+        auth.signOut(onError: showMessagePrompt) {/*success*/}
     }
     
     func deleteAccountFacebook() {

--- a/Buddies/Topics/TopicTabVC.swift
+++ b/Buddies/Topics/TopicTabVC.swift
@@ -42,8 +42,7 @@ class TopicTabVC: TopicsVC {
     }
     
 
-    func loadProfileData(uid: String = Auth.auth().currentUser!.uid,
-                         dataAccess: DataAccessor = DataAccessor.instance) -> Canceler {
+    func loadProfileData(dataAccess: DataAccessor = DataAccessor.instance) -> Canceler {
         
         return dataAccess.useLoggedInUser { user in
             self.user = user

--- a/BuddiesTests/AppDelegateTests.swift
+++ b/BuddiesTests/AppDelegateTests.swift
@@ -108,7 +108,7 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupInitialView(isLoggedIn: true) {
+        app.setupView(isLoggedOut: false, isInitial: true) {
             callback in callback(true)
         }
     }
@@ -119,7 +119,7 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupInitialView(isLoggedIn: false) {
+        app.setupView(isLoggedOut: true, isInitial: true) {
             callback in callback(true)
         }
     }
@@ -130,7 +130,7 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupInitialView(isLoggedIn: true) {
+        app.setupView(isLoggedOut: false, isInitial: true) {
             callback in callback(false)
         }
     }
@@ -141,7 +141,7 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupInitialView(isLoggedIn: false) {
+        app.setupView(isLoggedOut: true, isInitial: true) {
             callback in callback(false)
         }
     }

--- a/BuddiesTests/AppDelegateTests.swift
+++ b/BuddiesTests/AppDelegateTests.swift
@@ -15,92 +15,6 @@ class AppDelegateTests: XCTestCase {
     func testDelType() {
         XCTAssertNotNil(UIApplication.shared.delegate as? AppDelegate)
     }
-
-    func testGetHasUserDoc_UserNil() {
-        guard let app = UIApplication.shared.delegate as? AppDelegate else {
-            XCTAssertTrue(false, "No app delegate :(")
-            return
-        }
-
-        let expectation = self.expectation(description: "User doc confirmed bad")
-        
-        let ref = MockCollectionReference()
-        app.getHasUserDoc(callback: { result in
-            if !result { expectation.fulfill() }
-        }, uid: nil, dataAccess: nil, src: ref)
-        
-        waitForExpectations(timeout: 2)
-    }
-    
-    func testGetHasUserDoc_NoImage() {
-        guard let app = UIApplication.shared.delegate as? AppDelegate else {
-            XCTAssertTrue(false, "No app delegate :(")
-            return
-        }
-        
-        let expectation = self.expectation(description: "User doc confirmed bad")
-
-        let uid = MockExistingUser().uid
-        let doc = MockDocumentReference()
-        let ref = MockCollectionReference()
-        
-        ref.documents[uid] = doc
-        doc.exposedData["bio"] = "blah blah"
-        
-        app.getHasUserDoc(callback: { result in
-            if !result { expectation.fulfill() }
-        }, uid: uid, dataAccess: nil, src: ref)
-        
-        waitForExpectations(timeout: 2)
-    }
-    
-    func testGetHasUserDoc_NoBio() {
-        guard let app = UIApplication.shared.delegate as? AppDelegate else {
-            XCTAssertTrue(false, "No app delegate :(")
-            return
-        }
-        
-        let expectation = self.expectation(description: "User doc confirmed bad")
-        
-        let uid = MockExistingUser().uid
-        let doc = MockDocumentReference()
-        let ref = MockCollectionReference()
-        
-        ref.documents[uid] = doc
-        doc.exposedData["image_url"] = "my_image_url"
-        
-        app.getHasUserDoc(callback: { result in
-            if !result { expectation.fulfill() }
-        }, uid: uid, dataAccess: nil, src: ref)
-        
-        waitForExpectations(timeout: 2)
-    }
-    
-    func testGetHasUserDoc_Valid() {
-        guard let app = UIApplication.shared.delegate as? AppDelegate else {
-            XCTAssertTrue(false, "No app delegate :(")
-            return
-        }
-        
-        let expectation = self.expectation(description: "User doc confirmed good")
-        
-        let uid = MockExistingUser().uid
-        let doc = MockDocumentReference()
-        let ref = MockCollectionReference()
-        
-        ref.documents[uid] = doc
-        doc.exposedData["bio"] = "blah blah"
-        doc.exposedData["image_url"] = "my_image_url"
-        doc.exposedData["name"] = "george"
-        doc.exposedData["date_joined"] = Timestamp(date: Date())
-        
-        app.getHasUserDoc(callback: { result in
-            if result { expectation.fulfill() }
-            else { print("uh whoops") }
-        }, uid: uid, dataAccess: nil, src: ref)
-        
-        waitForExpectations(timeout: 2)
-    }
     
     func testSetupApp_LoggedInWithDoc() {
         guard let app = UIApplication.shared.delegate as? AppDelegate else {
@@ -108,9 +22,9 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupView(isLoggedOut: false, isInitial: true) {
-            callback in callback(true)
-        }
+        app.setupView(isLoggedOut: true,
+                      isInitial: true,
+                      needsAccountInfo: false)
     }
     
     func testSetupApp_LoggedOutWithDoc() {
@@ -119,9 +33,7 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupView(isLoggedOut: true, isInitial: true) {
-            callback in callback(true)
-        }
+        app.setupView(isLoggedOut: true, isInitial: true, needsAccountInfo: false)
     }
     
     func testSetupApp_LoggedInNoDoc() {
@@ -130,9 +42,7 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupView(isLoggedOut: false, isInitial: true) {
-            callback in callback(false)
-        }
+        app.setupView(isLoggedOut: false, isInitial: true, needsAccountInfo: true)
     }
     
     func testSetupApp_LoggedOutNoDoc() {
@@ -141,8 +51,6 @@ class AppDelegateTests: XCTestCase {
             return
         }
         
-        app.setupView(isLoggedOut: true, isInitial: true) {
-            callback in callback(false)
-        }
+        app.setupView(isLoggedOut: true, isInitial: true, needsAccountInfo: true)
     }
 }

--- a/BuddiesTests/Onboarding/LoginExistingVCTests.swift
+++ b/BuddiesTests/Onboarding/LoginExistingVCTests.swift
@@ -101,33 +101,4 @@ class LoginExistingVCTests: XCTestCase {
         
         XCTAssert(handler.nCallsLogInWithFacebook == 1, "Sign up with email should call logInWithFacebook")
     }
-    
-    func testHandleOnLogIn_HasDoc() {
-        let uid = MockExistingUser().uid
-        let app = MockAD(hasDoc: true)
-        
-        vc.handleOnLogIn(uid: uid, app: app)
-    }
-    
-    func testHandleOnLogIn_NoDoc() {
-        let uid = MockExistingUser().uid
-        let app = MockAD(hasDoc: false)
-        
-        vc.handleOnLogIn(uid: uid, app: app)
-    }
-    
-    func testHandleOnLogIn_nilApp() {
-        vc.handleOnLogIn(uid: "hello", app: nil)
-    }
-    
-    class MockAD : AppDelegate {
-        let hasDoc: Bool
-        init(hasDoc: Bool) { self.hasDoc = hasDoc }
-        override func getHasUserDoc(callback: @escaping (Bool) -> Void,
-                                    uid: String?,
-                                    dataAccess: DataAccessor?,
-                                    src: CollectionReference) {
-            callback(self.hasDoc)
-        }
-    }
 }


### PR DESCRIPTION
This moves the responsibility of navigating on auth changes to AppDelegate

Fixes #18 

To Test:
- Sign In
- Sign Up
- Sign Out
- Close/Reopen App
- Close/Reopen App before clicking "Finish" on profile 