### PR TITLE
Use 'bad' color for remove user button

### DIFF
--- a/Buddies/Activities/View Activity/ActivityUserCollectionCell.swift
+++ b/Buddies/Activities/View Activity/ActivityUserCollectionCell.swift
@@ -41,5 +41,7 @@ class ActivityUserCollectionCell: UICollectionViewCell {
         }
         userImage.image = user.image
         userImage.makeCircle()
+        self.removeButton.tintColor = Theme.bad
+        self.removeButton.titleLabel?.textColor = Theme.bad
     }
 }


### PR DESCRIPTION
I forgot to switch the remove user button to use the new theme color for "bad". Here it is. If you want, check out an activity you own to make sure the remove button by a user is the normal destructive red. On master, it's maroon.