### PR TITLE
BUD-147 Fix constraints on view activity

### DIFF
--- a/Buddies/Activities/View Activity/ActivityDescription.xib
+++ b/Buddies/Activities/View Activity/ActivityDescription.xib
@@ -41,7 +41,7 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Fx-Cv-PlK">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1BD-Ph-UYj">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="1BD-Ph-UYj">
                             <rect key="frame" x="20" y="20" width="49" height="32"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle1"/>
                             <nil key="textColor"/>

--- a/Buddies/Activities/View Activity/ActivityDescription.xib
+++ b/Buddies/Activities/View Activity/ActivityDescription.xib
@@ -119,11 +119,8 @@
                                 <action selector="onJoinTap:" destination="-1" eventType="touchUpInside" id="8JL-If-UoL"/>
                             </connections>
                         </button>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Next week" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MBj-Rw-ymJ">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" horizontalCompressionResistancePriority="740" text="Next week" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MBj-Rw-ymJ">
                             <rect key="frame" x="115" y="57" width="100" height="21"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="100" id="em0-oS-WUk"/>
-                            </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
@@ -169,7 +166,7 @@
                         <constraint firstItem="uBp-lP-0wh" firstAttribute="top" secondItem="oYt-RJ-04X" secondAttribute="bottom" constant="15" id="LOh-Y1-AVF"/>
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="trailing" secondItem="uBp-lP-0wh" secondAttribute="trailing" constant="20" id="LSA-l1-x5p"/>
                         <constraint firstItem="rc6-SZ-CsE" firstAttribute="centerX" secondItem="6Fx-Cv-PlK" secondAttribute="centerX" id="P2R-Zw-dzt"/>
-                        <constraint firstItem="1BD-Ph-UYj" firstAttribute="leading" secondItem="dD2-Xh-Hu7" secondAttribute="leading" constant="20" id="Skz-Lc-rD4"/>
+                        <constraint firstItem="1BD-Ph-UYj" firstAttribute="leading" secondItem="6Fx-Cv-PlK" secondAttribute="leading" constant="20" id="Skz-Lc-rD4"/>
                         <constraint firstItem="nBe-TR-yw0" firstAttribute="top" secondItem="1BD-Ph-UYj" secondAttribute="bottom" constant="2" id="TNR-2l-AjY"/>
                         <constraint firstItem="ljP-m1-Bup" firstAttribute="top" secondItem="Bum-mZ-tD9" secondAttribute="bottom" constant="30" id="Xd3-k2-bg5"/>
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MBj-Rw-ymJ" secondAttribute="trailing" constant="10" id="ZbE-o2-78g"/>
@@ -180,6 +177,7 @@
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="trailing" secondItem="ljP-m1-Bup" secondAttribute="trailing" constant="20" id="fbS-s7-pCy"/>
                         <constraint firstAttribute="trailing" secondItem="Bum-mZ-tD9" secondAttribute="trailing" constant="15" id="jHL-ba-naW"/>
                         <constraint firstItem="MBj-Rw-ymJ" firstAttribute="leading" secondItem="nBe-TR-yw0" secondAttribute="trailing" constant="5" identifier="seperatorToDate" id="kTN-iB-GIr"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1BD-Ph-UYj" secondAttribute="trailing" constant="20" id="ktZ-Qe-9sj"/>
                         <constraint firstItem="MBj-Rw-ymJ" firstAttribute="top" secondItem="1BD-Ph-UYj" secondAttribute="bottom" constant="5" id="mUh-PS-aJq"/>
                         <constraint firstItem="Khl-NW-sKH" firstAttribute="centerX" secondItem="6Fx-Cv-PlK" secondAttribute="centerX" id="mrR-Eo-nfC"/>
                         <constraint firstItem="Khl-NW-sKH" firstAttribute="top" relation="greaterThanOrEqual" secondItem="uBp-lP-0wh" secondAttribute="bottom" constant="5" id="ntE-Iv-sSk"/>

--- a/Buddies/Activities/View Activity/ActivityDescription.xib
+++ b/Buddies/Activities/View Activity/ActivityDescription.xib
@@ -172,7 +172,7 @@
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MBj-Rw-ymJ" secondAttribute="trailing" constant="10" id="ZbE-o2-78g"/>
                         <constraint firstItem="OfB-xg-0le" firstAttribute="top" secondItem="1BD-Ph-UYj" secondAttribute="bottom" constant="5" id="dJc-HU-ubH"/>
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="bottom" secondItem="uBp-lP-0wh" secondAttribute="bottom" constant="100" id="e3L-g8-fXo"/>
-                        <constraint firstItem="oYt-RJ-04X" firstAttribute="top" secondItem="ljP-m1-Bup" secondAttribute="bottom" constant="-13" id="eOT-VY-jaP"/>
+                        <constraint firstItem="oYt-RJ-04X" firstAttribute="top" secondItem="ljP-m1-Bup" secondAttribute="bottom" constant="5" id="eOT-VY-jaP"/>
                         <constraint firstItem="OfB-xg-0le" firstAttribute="leading" secondItem="dD2-Xh-Hu7" secondAttribute="leading" constant="20" id="eZx-Sd-iJr"/>
                         <constraint firstItem="dD2-Xh-Hu7" firstAttribute="trailing" secondItem="ljP-m1-Bup" secondAttribute="trailing" constant="20" id="fbS-s7-pCy"/>
                         <constraint firstAttribute="trailing" secondItem="Bum-mZ-tD9" secondAttribute="trailing" constant="15" id="jHL-ba-naW"/>


### PR DESCRIPTION
1. Removed an unnecessary width constraint on the width, so the date text doesn't get cut off.
2. Decreased the priority of date so that it crops before location crops.
3. Added a constraint to the trailing edge of the title so that it does ellipsis instead of running off the edge of the screen.
4. Edited the constraint on the bottom of the user collection view so that users don't render on top of the "topic" header.  

Resolves #101 and a few other weird constraints on the screen