### PR TITLE
View Other User Profiles

### DIFF
--- a/Buddies.xcodeproj/project.pbxproj
+++ b/Buddies.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		582D0FA822036C93004F71E3 /* StorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 582D0FA722036C93004F71E3 /* StorageManager.swift */; };
 		584C350C221BC192000442B2 /* ActivityTableVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 584C350B221BC192000442B2 /* ActivityTableVCTests.swift */; };
 		5854E62222371AEC007E7E8D /* TopicStubDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5854E62122371AEC007E7E8D /* TopicStubDataSource.swift */; };
-		5854E62622381756007E7E8D /* ProfileVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5854E62522381756007E7E8D /* ProfileVCTests.swift */; };
+		5854E62622381756007E7E8D /* OtherProfileVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5854E62522381756007E7E8D /* OtherProfileVCTests.swift */; };
 		5854E628223818A6007E7E8D /* TopicStubDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5854E627223818A6007E7E8D /* TopicStubDataSourceTests.swift */; };
 		5868DEE2221DEEAE008B86FE /* AlgoliaTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F8D98E22173E5200CDD081 /* AlgoliaTest.swift */; };
 		5868DEE3221DEEC3008B86FE /* AlgoliaMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F8D990221748F100CDD081 /* AlgoliaMock.swift */; };
@@ -47,6 +47,7 @@
 		58B41FDB2249476A001A3CA7 /* OtherProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FDA2249476A001A3CA7 /* OtherProfileVC.swift */; };
 		58B41FDD22495C15001A3CA7 /* OtherProfile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 58B41FDC22495C15001A3CA7 /* OtherProfile.storyboard */; };
 		58B41FDF224A6896001A3CA7 /* EmptyMessageBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FDE224A6896001A3CA7 /* EmptyMessageBackground.swift */; };
+		58B41FE1224A9571001A3CA7 /* LoggedInProfileVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FE0224A9571001A3CA7 /* LoggedInProfileVCTests.swift */; };
 		58B42611221CE7EE000ACB28 /* TopicActivityTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */; };
 		58DBF760221CB7B3008512B3 /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75E221CB7B3008512B3 /* ActivityTests.swift */; };
 		58DBF761221CB7B3008512B3 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75F221CB7B3008512B3 /* UserTests.swift */; };
@@ -164,7 +165,7 @@
 		583FD2DD220244F8005B2C75 /* TopicModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicModelTests.swift; sourceTree = "<group>"; };
 		584C350B221BC192000442B2 /* ActivityTableVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTableVCTests.swift; sourceTree = "<group>"; };
 		5854E62122371AEC007E7E8D /* TopicStubDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicStubDataSource.swift; sourceTree = "<group>"; };
-		5854E62522381756007E7E8D /* ProfileVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileVCTests.swift; sourceTree = "<group>"; };
+		5854E62522381756007E7E8D /* OtherProfileVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherProfileVCTests.swift; sourceTree = "<group>"; };
 		5854E627223818A6007E7E8D /* TopicStubDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicStubDataSourceTests.swift; sourceTree = "<group>"; };
 		5868DEE6221F0564008B86FE /* TopicTabVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicTabVC.swift; sourceTree = "<group>"; };
 		58705ECA22285CB700EFE9F2 /* Discover.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Discover.storyboard; sourceTree = "<group>"; };
@@ -182,6 +183,7 @@
 		58B41FDA2249476A001A3CA7 /* OtherProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherProfileVC.swift; sourceTree = "<group>"; };
 		58B41FDC22495C15001A3CA7 /* OtherProfile.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = OtherProfile.storyboard; sourceTree = "<group>"; };
 		58B41FDE224A6896001A3CA7 /* EmptyMessageBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyMessageBackground.swift; sourceTree = "<group>"; };
+		58B41FE0224A9571001A3CA7 /* LoggedInProfileVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedInProfileVCTests.swift; sourceTree = "<group>"; };
 		58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicActivityTableVC.swift; sourceTree = "<group>"; };
 		58DBF75E221CB7B3008512B3 /* ActivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTests.swift; sourceTree = "<group>"; };
 		58DBF75F221CB7B3008512B3 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
@@ -506,7 +508,8 @@
 			isa = PBXGroup;
 			children = (
 				A9203537220CD4E400D115F2 /* DeleteAccountVCTests.swift */,
-				5854E62522381756007E7E8D /* ProfileVCTests.swift */,
+				5854E62522381756007E7E8D /* OtherProfileVCTests.swift */,
+				58B41FE0224A9571001A3CA7 /* LoggedInProfileVCTests.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -1021,6 +1024,7 @@
 				58EF8DA82208A2C600872770 /* DiscoverTableVCTests.swift in Sources */,
 				58EF8DA32208A2BC00872770 /* CreateActivityVCTests.swift in Sources */,
 				5868DEE3221DEEC3008B86FE /* AlgoliaMock.swift in Sources */,
+				58B41FE1224A9571001A3CA7 /* LoggedInProfileVCTests.swift in Sources */,
 				A9C98530221FB1E5003462AC /* TopicActivityTableVCTests.swift in Sources */,
 				A8B2F37C22040710006B91D1 /* NotificationServiceTest.swift in Sources */,
 				A95B958C2214B6A800453AEA /* DataAccessorTests.swift in Sources */,
@@ -1035,7 +1039,7 @@
 				A91BA3372202404600DED6B3 /* LoginVCTests.swift in Sources */,
 				58DBF761221CB7B3008512B3 /* UserTests.swift in Sources */,
 				A91BA33C22024D0E00DED6B3 /* MockAuthHandler.swift in Sources */,
-				5854E62622381756007E7E8D /* ProfileVCTests.swift in Sources */,
+				5854E62622381756007E7E8D /* OtherProfileVCTests.swift in Sources */,
 				A91BA33A22024A8900DED6B3 /* LoginExistingVCTests.swift in Sources */,
 				A9E8BF6622023D2E00C05F2C /* UIViewControlTests.swift in Sources */,
 				58A00330222F10BD002522C0 /* TopicVCTests.swift in Sources */,

--- a/Buddies.xcodeproj/project.pbxproj
+++ b/Buddies.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		58A5A40722025C2B00E0BF38 /* TopicCellTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58A5A40622025C2B00E0BF38 /* TopicCellTest.swift */; };
 		58A915B9220E2A5F008C325F /* PickTopics.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 58A915B8220E2A5F008C325F /* PickTopics.storyboard */; };
 		58AAA6752203F52E00AA538A /* Initialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58AAA6742203F52E00AA538A /* Initialization.swift */; };
+		58B41FD922494758001A3CA7 /* LoggedInProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FD822494758001A3CA7 /* LoggedInProfileVC.swift */; };
+		58B41FDB2249476A001A3CA7 /* OtherProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FDA2249476A001A3CA7 /* OtherProfileVC.swift */; };
+		58B41FDD22495C15001A3CA7 /* OtherProfile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 58B41FDC22495C15001A3CA7 /* OtherProfile.storyboard */; };
 		58B42611221CE7EE000ACB28 /* TopicActivityTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */; };
 		58DBF760221CB7B3008512B3 /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75E221CB7B3008512B3 /* ActivityTests.swift */; };
 		58DBF761221CB7B3008512B3 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75F221CB7B3008512B3 /* UserTests.swift */; };
@@ -78,7 +81,6 @@
 		A91BA3372202404600DED6B3 /* LoginVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91BA3362202404600DED6B3 /* LoginVCTests.swift */; };
 		A91BA33A22024A8900DED6B3 /* LoginExistingVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91BA33922024A8900DED6B3 /* LoginExistingVCTests.swift */; };
 		A91BA33C22024D0E00DED6B3 /* MockAuthHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91BA33B22024D0E00DED6B3 /* MockAuthHandler.swift */; };
-		A91BA33E22027BFD00DED6B3 /* ProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91BA33D22027BFD00DED6B3 /* ProfileVC.swift */; };
 		A9203538220CD4E500D115F2 /* DeleteAccountVCTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9203537220CD4E400D115F2 /* DeleteAccountVCTests.swift */; };
 		A95B958522133DDB00453AEA /* DataAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95B958422133DDB00453AEA /* DataAccessor.swift */; };
 		A95B958822133FA500453AEA /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = A95B958722133FA500453AEA /* User.swift */; };
@@ -175,6 +177,9 @@
 		58A915B8220E2A5F008C325F /* PickTopics.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PickTopics.storyboard; sourceTree = "<group>"; };
 		58AAA6742203F52E00AA538A /* Initialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Initialization.swift; sourceTree = "<group>"; };
 		58AAA6762203FD3A00AA538A /* TopicCollectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicCollectionTests.swift; sourceTree = "<group>"; };
+		58B41FD822494758001A3CA7 /* LoggedInProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedInProfileVC.swift; sourceTree = "<group>"; };
+		58B41FDA2249476A001A3CA7 /* OtherProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherProfileVC.swift; sourceTree = "<group>"; };
+		58B41FDC22495C15001A3CA7 /* OtherProfile.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = OtherProfile.storyboard; sourceTree = "<group>"; };
 		58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicActivityTableVC.swift; sourceTree = "<group>"; };
 		58DBF75E221CB7B3008512B3 /* ActivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTests.swift; sourceTree = "<group>"; };
 		58DBF75F221CB7B3008512B3 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
@@ -214,7 +219,6 @@
 		A91BA3362202404600DED6B3 /* LoginVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginVCTests.swift; sourceTree = "<group>"; };
 		A91BA33922024A8900DED6B3 /* LoginExistingVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginExistingVCTests.swift; sourceTree = "<group>"; };
 		A91BA33B22024D0E00DED6B3 /* MockAuthHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthHandler.swift; sourceTree = "<group>"; };
-		A91BA33D22027BFD00DED6B3 /* ProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileVC.swift; sourceTree = "<group>"; };
 		A9203537220CD4E400D115F2 /* DeleteAccountVCTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountVCTests.swift; sourceTree = "<group>"; };
 		A95B958422133DDB00453AEA /* DataAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataAccessor.swift; sourceTree = "<group>"; };
 		A95B958722133FA500453AEA /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
@@ -443,6 +447,7 @@
 				58A915B8220E2A5F008C325F /* PickTopics.storyboard */,
 				58705ECA22285CB700EFE9F2 /* Discover.storyboard */,
 				4568210B223AD89A008368A4 /* MyActivities.storyboard */,
+				58B41FDC22495C15001A3CA7 /* OtherProfile.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -466,9 +471,10 @@
 		58F2E9052208C05100D15214 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
-				A91BA33D22027BFD00DED6B3 /* ProfileVC.swift */,
 				45FED0AE220A657100B90C3B /* DeleteAccountVC.swift */,
 				A9B144AE220B4165004C614E /* SettingsVC.swift */,
+				58B41FD822494758001A3CA7 /* LoggedInProfileVC.swift */,
+				58B41FDA2249476A001A3CA7 /* OtherProfileVC.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";
@@ -823,6 +829,7 @@
 				58EF8DC02208BE5E00872770 /* LaunchScreen.storyboard in Resources */,
 				588289F8222C2A02009FEFC8 /* ActivityCell.xib in Resources */,
 				45FED0AD220A5F0300B90C3B /* Profile.storyboard in Resources */,
+				58B41FDD22495C15001A3CA7 /* OtherProfile.storyboard in Resources */,
 				58A915B9220E2A5F008C325F /* PickTopics.storyboard in Resources */,
 				B688B477221C74610031A364 /* ViewActivity.storyboard in Resources */,
 				B6AC54A621F8DB8500B075B8 /* Assets.xcassets in Resources */,
@@ -981,10 +988,11 @@
 				58EF8DBF2208BE5E00872770 /* BuddiesStoryboard.swift in Sources */,
 				458CE72C220D36DC00012637 /* SearchTextField.swift in Sources */,
 				457F576B2218C54C00F27BFE /* ActivityTableVC.swift in Sources */,
-				A91BA33E22027BFD00DED6B3 /* ProfileVC.swift in Sources */,
 				A95B958522133DDB00453AEA /* DataAccessor.swift in Sources */,
+				58B41FD922494758001A3CA7 /* LoggedInProfileVC.swift in Sources */,
 				458CE72E220D472200012637 /* MapItemSearchResult.swift in Sources */,
 				B688B47D221CCBAE0031A364 /* ActivityChatController.swift in Sources */,
+				58B41FDB2249476A001A3CA7 /* OtherProfileVC.swift in Sources */,
 				A9ADCDCC2223383300D12EB4 /* DateRangeSliderDelegate.swift in Sources */,
 				45FED0AF220A657100B90C3B /* DeleteAccountVC.swift in Sources */,
 				450779E02210D7B00008D0DF /* RangeSeekSlider.swift in Sources */,

--- a/Buddies.xcodeproj/project.pbxproj
+++ b/Buddies.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		58B41FD922494758001A3CA7 /* LoggedInProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FD822494758001A3CA7 /* LoggedInProfileVC.swift */; };
 		58B41FDB2249476A001A3CA7 /* OtherProfileVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FDA2249476A001A3CA7 /* OtherProfileVC.swift */; };
 		58B41FDD22495C15001A3CA7 /* OtherProfile.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 58B41FDC22495C15001A3CA7 /* OtherProfile.storyboard */; };
+		58B41FDF224A6896001A3CA7 /* EmptyMessageBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B41FDE224A6896001A3CA7 /* EmptyMessageBackground.swift */; };
 		58B42611221CE7EE000ACB28 /* TopicActivityTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */; };
 		58DBF760221CB7B3008512B3 /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75E221CB7B3008512B3 /* ActivityTests.swift */; };
 		58DBF761221CB7B3008512B3 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75F221CB7B3008512B3 /* UserTests.swift */; };
@@ -180,6 +181,7 @@
 		58B41FD822494758001A3CA7 /* LoggedInProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedInProfileVC.swift; sourceTree = "<group>"; };
 		58B41FDA2249476A001A3CA7 /* OtherProfileVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OtherProfileVC.swift; sourceTree = "<group>"; };
 		58B41FDC22495C15001A3CA7 /* OtherProfile.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = OtherProfile.storyboard; sourceTree = "<group>"; };
+		58B41FDE224A6896001A3CA7 /* EmptyMessageBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyMessageBackground.swift; sourceTree = "<group>"; };
 		58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicActivityTableVC.swift; sourceTree = "<group>"; };
 		58DBF75E221CB7B3008512B3 /* ActivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTests.swift; sourceTree = "<group>"; };
 		58DBF75F221CB7B3008512B3 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
@@ -535,6 +537,7 @@
 				450779DB2210D7B00008D0DF /* RangeSeekSliderDelegate.swift */,
 				450779DC2210D7B00008D0DF /* TapticEngine.swift */,
 				458CE72B220D36DC00012637 /* SearchTextField.swift */,
+				58B41FDE224A6896001A3CA7 /* EmptyMessageBackground.swift */,
 			);
 			path = _ThirdParty;
 			sourceTree = "<group>";
@@ -967,6 +970,7 @@
 				582D0FA822036C93004F71E3 /* StorageManager.swift in Sources */,
 				A9E8BF472201534D00C05F2C /* LoginExistingVC.swift in Sources */,
 				5802266A220BE5E90068E08E /* ToggleButton.swift in Sources */,
+				58B41FDF224A6896001A3CA7 /* EmptyMessageBackground.swift in Sources */,
 				A9E8BF402201427A00C05F2C /* LoginVC.swift in Sources */,
 				45DA93A8220957CE0064CBEF /* Testing.swift in Sources */,
 				A9C9852C221E658C003462AC /* FilterSearchBar.swift in Sources */,

--- a/Buddies/Activities/ActivityCell.swift
+++ b/Buddies/Activities/ActivityCell.swift
@@ -34,4 +34,37 @@ class ActivityCell: UITableViewCell {
             memberPic.imageView?.clipsToBounds = true
         }
     }
+    
+    func format(using activity: Activity, userImages: [UIImage]) {
+        
+        titleLabel.text = activity.title
+        descriptionLabel.text = activity.description
+        locationLabel.text = activity.locationText
+        
+        let dateRange = DateInterval(start: activity.startTime.dateValue(),
+                                     end: activity.endTime.dateValue())
+        
+        
+        let pixelsPerChar: CGFloat = 10.0
+        
+        let charsFitInCell = Int(frame.width/pixelsPerChar)
+        
+        let locStrLength = max(15, charsFitInCell - activity.title.count)
+        
+        let locStr = dateRange.rangePhrase(relativeTo: Date(), tryShorteningIfLongerThan: locStrLength)
+        
+        dateLabel.text = locStr.capitalized
+        
+        zip(memberPics, userImages).forEach() { (btn, img) in
+            btn.setImage(img, for: .normal)
+        }
+        
+        
+        // hide "..." as needed
+        if activity.members.count <= 3{
+            extraPicturesLabel.isHidden = true
+        } else {
+            extraPicturesLabel.isHidden = false
+        }
+    }
 }

--- a/Buddies/Activities/ActivityCell.xib
+++ b/Buddies/Activities/ActivityCell.xib
@@ -41,7 +41,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="right" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xmi-eD-txk">
-                        <rect key="frame" x="293" y="85" width="48" height="14.5"/>
+                        <rect key="frame" x="273" y="85" width="48" height="14.5"/>
                         <fontDescription key="fontDescription" type="system" weight="light" pointSize="12"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -110,7 +110,7 @@
                     <constraint firstAttribute="bottom" secondItem="a5l-Zo-WAK" secondAttribute="bottom" constant="10" id="NU7-tn-Nl1"/>
                     <constraint firstItem="a5l-Zo-WAK" firstAttribute="leading" secondItem="gw1-cE-j4f" secondAttribute="trailing" constant="8" id="OSG-sG-hTP"/>
                     <constraint firstAttribute="trailing" secondItem="APC-Ky-HEV" secondAttribute="trailing" id="Opx-4r-Nml"/>
-                    <constraint firstAttribute="trailing" secondItem="Xmi-eD-txk" secondAttribute="trailing" id="PMq-Yg-L29"/>
+                    <constraint firstAttribute="trailing" secondItem="Xmi-eD-txk" secondAttribute="trailing" constant="20" id="PMq-Yg-L29"/>
                     <constraint firstItem="Ju9-ey-FZf" firstAttribute="leading" secondItem="5ag-QT-gc9" secondAttribute="leading" constant="20" id="PrT-dh-qzx"/>
                     <constraint firstItem="hfs-Ad-S4m" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ju9-ey-FZf" secondAttribute="trailing" constant="5" id="US6-N3-ros"/>
                     <constraint firstAttribute="bottom" secondItem="Xmi-eD-txk" secondAttribute="bottom" constant="10" id="Wh1-ho-GXz"/>

--- a/Buddies/Activities/ActivityCell.xib
+++ b/Buddies/Activities/ActivityCell.xib
@@ -41,7 +41,7 @@
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="right" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xmi-eD-txk">
-                        <rect key="frame" x="273" y="85" width="48" height="14.5"/>
+                        <rect key="frame" x="293" y="85" width="48" height="14.5"/>
                         <fontDescription key="fontDescription" type="system" weight="light" pointSize="12"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
@@ -110,7 +110,7 @@
                     <constraint firstAttribute="bottom" secondItem="a5l-Zo-WAK" secondAttribute="bottom" constant="10" id="NU7-tn-Nl1"/>
                     <constraint firstItem="a5l-Zo-WAK" firstAttribute="leading" secondItem="gw1-cE-j4f" secondAttribute="trailing" constant="8" id="OSG-sG-hTP"/>
                     <constraint firstAttribute="trailing" secondItem="APC-Ky-HEV" secondAttribute="trailing" id="Opx-4r-Nml"/>
-                    <constraint firstAttribute="trailing" secondItem="Xmi-eD-txk" secondAttribute="trailing" constant="20" id="PMq-Yg-L29"/>
+                    <constraint firstAttribute="trailing" secondItem="Xmi-eD-txk" secondAttribute="trailing" id="PMq-Yg-L29"/>
                     <constraint firstItem="Ju9-ey-FZf" firstAttribute="leading" secondItem="5ag-QT-gc9" secondAttribute="leading" constant="20" id="PrT-dh-qzx"/>
                     <constraint firstItem="hfs-Ad-S4m" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Ju9-ey-FZf" secondAttribute="trailing" constant="5" id="US6-N3-ros"/>
                     <constraint firstAttribute="bottom" secondItem="Xmi-eD-txk" secondAttribute="bottom" constant="10" id="Wh1-ho-GXz"/>

--- a/Buddies/Activities/ActivityTableVC.swift
+++ b/Buddies/Activities/ActivityTableVC.swift
@@ -166,11 +166,12 @@ class ActivityTableVC: UITableViewController, FilterSearchBarDelegate {
         let cell = tableView.dequeueReusableCell(withIdentifier: "ActivityCell", for: indexPath) as! ActivityCell
     
         if let activity = getActivity(at: indexPath) {
-            return format(cell: cell, using: activity, at: indexPath)
+            let activityUserImages = activity.members.compactMap { users[$0]?.image }
+            cell.format(using: activity, userImages: activityUserImages)
         } else {
             cell.isHidden = true
-            return cell
         }
+        return cell
     }
     
     override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -180,41 +181,7 @@ class ActivityTableVC: UITableViewController, FilterSearchBarDelegate {
             return 0
         }
     }
-    
-    func format(cell: ActivityCell, using activity: Activity, at indexPath: IndexPath) -> ActivityCell{
-        
-        cell.titleLabel.text = activity.title
-        cell.descriptionLabel.text = activity.description
-        cell.locationLabel.text = activity.locationText
-        let dateRange = DateInterval(start: activity.startTime.dateValue(),
-                                     end: activity.endTime.dateValue())
-    
-        
-        let pixelsPerChar: CGFloat = 10.0
-        
-        let charsFitInCell = Int(cell.frame.width/pixelsPerChar)
-        
-        let locStrLength = max(15, charsFitInCell - activity.title.count)
-        
-        let locStr = dateRange.rangePhrase(relativeTo: Date(), tryShorteningIfLongerThan: locStrLength)
-        
-        cell.dateLabel.text = locStr.capitalized
 
-        let activityUserImages = activity.members.compactMap { users[$0]?.image }
-        
-        zip(cell.memberPics, activityUserImages).forEach() { (btn, img) in btn.setImage(img, for: .normal)
-        }
-        
-
-        // hide "..." as needed
-        if activity.members.count <= 3{
-            cell.extraPicturesLabel.isHidden = true
-        } else {
-            cell.extraPicturesLabel.isHidden = false
-        }
-        
-        return cell
-    }
     
     func getActivity(at indexPath: IndexPath) -> Activity? {
         return activities[indexPath.section][indexPath.row]

--- a/Buddies/Activities/ActivityTableVC.swift
+++ b/Buddies/Activities/ActivityTableVC.swift
@@ -193,6 +193,11 @@ class ActivityTableVC: UITableViewController, FilterSearchBarDelegate {
     }
     
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if (displayIds.flatMap { $0 }).count == 0 {
+            tableView.setEmptyMessage("No results")
+        } else {
+            tableView.restore()
+        }
         return displayIds[section].count
     }
     

--- a/Buddies/Activities/View Activity/ActivityDescriptionController.swift
+++ b/Buddies/Activities/View Activity/ActivityDescriptionController.swift
@@ -68,6 +68,7 @@ class ActivityDescriptionController: UIView, UICollectionViewDataSource, UIColle
     }
 
     var removeUser: ((_ uid: String) -> Void)?
+    var tapUser: ((_ uid: String) -> Void)?
 
     // MARK: Local data sources for rendering:
     var topics: [Topic] = []
@@ -87,6 +88,7 @@ class ActivityDescriptionController: UIView, UICollectionViewDataSource, UIColle
         onExpand: @escaping () -> Void,
         onLeave: @escaping () -> Void,
         onRemoveUser: @escaping (_ uid: String) -> Void,
+        onTapUser: @escaping (_ uid: String) -> Void,
         onDeleteActivity: @escaping () -> Void,
         onJoin: @escaping () -> Void ) {
 
@@ -105,6 +107,7 @@ class ActivityDescriptionController: UIView, UICollectionViewDataSource, UIColle
         self.toggleBigView = onExpand
         self.leaveActivity = onLeave
         self.removeUser = onRemoveUser
+        self.tapUser = onTapUser
         self.deleteActivity = onDeleteActivity
 
         // Set UI elements to new data:
@@ -206,7 +209,7 @@ class ActivityDescriptionController: UIView, UICollectionViewDataSource, UIColle
             let user = users[indexPath.row]
             let isIndividualOwner = self.curActivity?.getMemberStatus(of: user.uid) == .owner
             let isCurUserOwner = self.memberStatus == .owner
-            cell.render(withUser: users[indexPath.row], isCurUserOwner: isCurUserOwner, isIndividualOwner: isIndividualOwner, removeUser: self.removeUser)
+            cell.render(withUser: users[indexPath.row], isCurUserOwner: isCurUserOwner, isIndividualOwner: isIndividualOwner, tapUser: self.tapUser, removeUser: self.removeUser)
             return cell
         } else {
             return UICollectionViewCell()

--- a/Buddies/Activities/View Activity/ActivityUserCollectionCell.swift
+++ b/Buddies/Activities/View Activity/ActivityUserCollectionCell.swift
@@ -15,18 +15,27 @@ class ActivityUserCollectionCell: UICollectionViewCell {
     @IBOutlet weak var removeButton: UIButton!
     
     private var removeUser: ((_ uid: String) -> Void)?
+    private var tapUser: ((_ uid: String) -> Void)?
+    
     @IBAction func onRemoveUser(_ sender: UIButton) {
         guard let uid = curUid else { return }
         removeUser?(uid)
     }
+    
+    @IBAction func onTapUser(_ sender: Any) {
+        guard let uid = curUid else { return }
+        tapUser?(uid)
+    }
 
+    
     private var curUid: String?
 
-    func render(withUser user: User, isCurUserOwner: Bool, isIndividualOwner: Bool, removeUser: ((_ uid: String)->Void)?) {
+    func render(withUser user: User, isCurUserOwner: Bool, isIndividualOwner: Bool, tapUser: ((_ uid: String)->Void)?, removeUser: ((_ uid: String)->Void)?) {
         userName.text = user.name
         curUid = user.uid
 
         self.removeUser = removeUser
+        self.tapUser = tapUser
         if (isIndividualOwner) {
             userName.text?.append(" (owner)")
         }

--- a/Buddies/Activities/View Activity/ActivityUserCollectionCell.xib
+++ b/Buddies/Activities/View Activity/ActivityUserCollectionCell.xib
@@ -43,15 +43,25 @@
                             <constraint firstAttribute="height" constant="40" id="XVH-xj-pP3"/>
                         </constraints>
                     </imageView>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uyh-eM-DHG" userLabel="onTapArea">
+                        <rect key="frame" x="0.0" y="0.0" width="203" height="50"/>
+                        <connections>
+                            <action selector="onTapUser:" destination="gTV-IL-0wX" eventType="touchUpInside" id="KMW-I2-dBh"/>
+                        </connections>
+                    </button>
                 </subviews>
             </view>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="HIW-6c-6EV" secondAttribute="trailing" constant="5" id="01r-8T-MLe"/>
                 <constraint firstItem="9A9-N2-27N" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="5" id="0Go-AH-4Cj"/>
+                <constraint firstItem="uyh-eM-DHG" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="7gR-Pt-bkH"/>
                 <constraint firstItem="5a4-ao-Pel" firstAttribute="centerY" secondItem="gTV-IL-0wX" secondAttribute="centerY" id="E72-Qv-JwS"/>
                 <constraint firstItem="9A9-N2-27N" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" constant="5" id="EV8-r4-gba"/>
+                <constraint firstItem="uyh-eM-DHG" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="Njg-k7-7Yy"/>
                 <constraint firstAttribute="bottom" secondItem="9A9-N2-27N" secondAttribute="bottom" constant="5" id="O6S-VA-yyF"/>
                 <constraint firstItem="HIW-6c-6EV" firstAttribute="centerY" secondItem="gTV-IL-0wX" secondAttribute="centerY" id="QeS-Xg-05N"/>
+                <constraint firstAttribute="bottom" secondItem="uyh-eM-DHG" secondAttribute="bottom" id="dDJ-P1-Dre"/>
+                <constraint firstItem="HIW-6c-6EV" firstAttribute="leading" secondItem="uyh-eM-DHG" secondAttribute="trailing" id="e14-Lq-anq"/>
                 <constraint firstItem="HIW-6c-6EV" firstAttribute="leading" secondItem="5a4-ao-Pel" secondAttribute="trailing" constant="5" id="izB-5c-7IM"/>
                 <constraint firstItem="5a4-ao-Pel" firstAttribute="leading" secondItem="9A9-N2-27N" secondAttribute="trailing" constant="10" id="wb3-t4-npi"/>
             </constraints>

--- a/Buddies/Activities/View Activity/ViewActivityController.swift
+++ b/Buddies/Activities/View Activity/ViewActivityController.swift
@@ -69,13 +69,13 @@ class ViewActivityController: UIViewController {
     
     // Adds the current user to the activity
     // if they are not yet in it.
-    func joinActivity() -> Void {
+    func joinActivity() {
         let uid = Auth.auth().currentUser!.uid
         guard let activity = self.curActivity else { return }
         activity.addMember(with: uid)
     }
 
-    func leaveActivity() -> Void {
+    func leaveActivity() {
         showCancelableAlert(withMsg: "Are you sure you want to leave this activity?", withTitle: "Leave Activity", withAction: "Leave") { didConfirm, msg in
             guard didConfirm,
                 let uid = Auth.auth().currentUser?.uid,
@@ -87,15 +87,22 @@ class ViewActivityController: UIViewController {
         }
     }
 
-    func removeUser(uid: String) -> Void {
+    func removeUser(uid: String) {
         showCancelableAlert(withMsg: "Are you sure you want to remove this user?", withTitle: "Remove User", withAction: "Remove") { didConfirm, msg in
             guard didConfirm,
                 let activity = self.curActivity else { return }
             activity.removeMember(with: uid)
         }
     }
+    
+    func tapUser(_ uid: String) {
+        if let userProfile = BuddiesStoryboard.OtherProfile.viewController(withID: "otherProfile") as? OtherProfileVC {
+            userProfile.userId = uid
+            self.navigationController?.pushViewController(userProfile, animated: true)
+        }
+    }
 
-    func deleteActivity() -> Void {
+    func deleteActivity() {
         showCancelableAlert(withMsg: "Are you sure you want to delete this activity?", withTitle: "Delete Activity", withAction: "Delete") { didConfirm, msg in
             guard didConfirm,
                 let activity = self.curActivity,
@@ -128,7 +135,7 @@ class ViewActivityController: UIViewController {
 
     // Local state for toggling the expanded description
     var shouldExpand = false
-    func expandDescription() -> Void {
+    func expandDescription() {
         shouldExpand = !shouldExpand
         render()
     }
@@ -220,6 +227,7 @@ class ViewActivityController: UIViewController {
             onExpand: self.expandDescription,
             onLeave: self.leaveActivity,
             onRemoveUser: self.removeUser,
+            onTapUser: self.tapUser,
             onDeleteActivity: self.deleteActivity,
             onJoin: self.joinActivity )
 

--- a/Buddies/Profile/LoggedInProfileVC.swift
+++ b/Buddies/Profile/LoggedInProfileVC.swift
@@ -1,0 +1,101 @@
+//
+//  LoggedInUserProfileVC.swift
+//  Buddies
+//
+//  Created by Luke Meier on 3/25/19.
+//  Copyright © 2019 Jack and the Beans. All rights reserved.
+//
+
+import UIKit
+import Firebase
+
+class LoggedInProfileVC: UIViewController, UICollectionViewDelegateFlowLayout {
+    @IBOutlet weak var profilePic: UIButton!
+    @IBOutlet weak var bioLabel: UILabel!
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var favoriteTopicsCollection: UICollectionView!
+    
+    
+    var userActivities = [Activity]()
+    
+    var user: User?
+    
+    var dataSource: TopicStubDataSource!
+    
+    var stopListeningToUser: Canceler?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        favoriteTopicsCollection.register(
+            UINib.init(nibName: "ActivityTopicCollectionCell", bundle: nil),
+            forCellWithReuseIdentifier: "topic_cell"
+        )
+        
+        setupDataSource()
+        
+        stopListeningToUser = stopListeningToUser ?? loadProfileData()
+    }
+    
+    deinit {
+        stopListeningToUser?()
+    }
+    
+    func setupDataSource(){
+        dataSource = TopicStubDataSource()
+        
+        favoriteTopicsCollection.dataSource = dataSource
+        favoriteTopicsCollection.delegate = self
+    }
+    
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        
+        profilePic.layer.cornerRadius = profilePic.frame.size.width / 2
+        profilePic.clipsToBounds = true
+    }
+    
+    func loadProfileData(storageManger: StorageManager = StorageManager.shared,
+                         dataAccess: DataAccessor = DataAccessor.instance) -> Canceler {
+        return dataAccess.useLoggedInUser { user in
+            guard let user = user else { return }
+            self.user = user
+            self.render(with: user)
+        }
+    }
+    
+    func render(with user: User){
+        self.bioLabel.text = user.bio
+        self.nameLabel.text = user.name
+        
+        self.dataSource.topics = self.getTopics(from: user.favoriteTopics)
+        self.favoriteTopicsCollection.reloadData()
+        
+        // If something else changes, don't reload the image.
+        if let image = user.image {
+            self.onImageLoaded(image: image)
+        }
+    }
+    
+    //MARK: - UICollectionViewDelegateFlowLayout
+    
+    // The VC is the delegate because it knows about the collectionView's frame
+    
+    // Dynamically sizes the topic cells based on the screen size
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        return self.dataSource.getTopicSize(frameWidth: view.frame.width)
+    }
+    
+    func onImageLoaded(image: UIImage) {
+        profilePic.tintColor = UIColor.clear
+        profilePic.setImage(image, for: .normal)
+    }
+    
+    // Gets topics from the root topic store
+    func getTopics(from topicIds: [String]) -> [Topic] {
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let topics = appDelegate.topicCollection.topics.filter { topicIds.contains($0.id) }
+        return topics
+    }
+    
+}

--- a/Buddies/Profile/OtherProfileVC.swift
+++ b/Buddies/Profile/OtherProfileVC.swift
@@ -15,12 +15,13 @@ class OtherProfileVC: UIViewController, UICollectionViewDelegateFlowLayout, UITa
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var favoriteTopicsCollection: UICollectionView!
     @IBOutlet weak var activityTable: UITableView!
+    @IBOutlet weak var reportButton: UIBarButtonItem!
     
     
     var userActivities = [Activity]()
    
     var user: User?
-    var userId: UserId!
+    var userId: UserId! 
     
     var dataSource: TopicStubDataSource!
     

--- a/Buddies/Profile/OtherProfileVC.swift
+++ b/Buddies/Profile/OtherProfileVC.swift
@@ -17,6 +17,7 @@ class OtherProfileVC: UIViewController, UICollectionViewDelegateFlowLayout, UITa
     @IBOutlet weak var activityTable: UITableView!
     @IBOutlet weak var reportButton: UIBarButtonItem!
     
+    let maxPrevActivities = 4
     
     var userActivities = [Activity]()
    
@@ -137,7 +138,7 @@ class OtherProfileVC: UIViewController, UICollectionViewDelegateFlowLayout, UITa
             activityTable.restore()
         }
         
-        return min(4, userActivities.count)
+        return min(maxPrevActivities, userActivities.count)
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -146,6 +147,7 @@ class OtherProfileVC: UIViewController, UICollectionViewDelegateFlowLayout, UITa
         
         if let activity = getActivity(at: indexPath) {
             cell.format(using: activity, userImages: [])
+            cell.extraPicturesLabel.isHidden = true
             cell.accessoryType = .none
         }
         return cell

--- a/Buddies/Profile/OtherProfileVC.swift
+++ b/Buddies/Profile/OtherProfileVC.swift
@@ -1,21 +1,45 @@
 //
-//  ProfileVC.swift
+//  OtherProfileVC.swift
 //  Buddies
 //
-//  Created by Jake Thurman on 1/30/19.
+//  Created by Luke Meier on 3/25/19.
 //  Copyright © 2019 Jack and the Beans. All rights reserved.
 //
 
 import UIKit
 import Firebase
 
-class ProfileVC: UIViewController, UICollectionViewDelegateFlowLayout {
-    
+class OtherProfileVC: UIViewController, UICollectionViewDelegateFlowLayout, UITableViewDataSource {
     @IBOutlet weak var profilePic: UIButton!
     @IBOutlet weak var bioLabel: UILabel!
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var favoriteTopicsCollection: UICollectionView!
+    @IBOutlet weak var activityTable: UITableView!
     
+    
+    var userActivities = [Activity]()
+    
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 3
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        let cell = tableView.dequeueReusableCell(withIdentifier: "ActivityCell", for: indexPath) as! ActivityCell
+        
+        if let activity = getActivity(at: indexPath) {
+            cell.format(using: activity, userImages: [])
+        }
+        return cell
+        
+    }
+    
+    func getActivity(at indexPath: IndexPath) -> Activity? {
+        return userActivities[indexPath.row]
+    }
+
+   
     var user: User?
     
     var dataSource: TopicStubDataSource!
@@ -24,6 +48,11 @@ class ProfileVC: UIViewController, UICollectionViewDelegateFlowLayout {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        activityTable.register(
+            UINib(nibName: "ActivityCell", bundle: nil),
+            forCellReuseIdentifier: "ActivityCell"
+        )
         
         favoriteTopicsCollection.register(
             UINib.init(nibName: "ActivityTopicCollectionCell", bundle: nil),
@@ -54,7 +83,7 @@ class ProfileVC: UIViewController, UICollectionViewDelegateFlowLayout {
     }
     
     func loadProfileData(storageManger: StorageManager = StorageManager.shared,
-                          dataAccess: DataAccessor = DataAccessor.instance) -> Canceler {
+                         dataAccess: DataAccessor = DataAccessor.instance) -> Canceler {
         return dataAccess.useLoggedInUser { user in
             guard let user = user else { return }
             self.user = user

--- a/Buddies/Profile/OtherProfileVC.swift
+++ b/Buddies/Profile/OtherProfileVC.swift
@@ -151,6 +151,8 @@ class OtherProfileVC: UIViewController, UICollectionViewDelegateFlowLayout, UITa
         return cell
         
     }
+
+
     
     func getActivity(at indexPath: IndexPath) -> Activity? {
         return userActivities[indexPath.row]

--- a/Buddies/Profile/OtherProfileVC.swift
+++ b/Buddies/Profile/OtherProfileVC.swift
@@ -131,6 +131,12 @@ class OtherProfileVC: UIViewController, UICollectionViewDelegateFlowLayout, UITa
     //MARK: - UITableViewDataSource
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        if userActivities.count == 0 {
+            activityTable.setEmptyMessage("No previous activities")
+        } else {
+            activityTable.restore()
+        }
+        
         return min(4, userActivities.count)
     }
     

--- a/Buddies/Storyboards/BuddiesStoryboard.swift
+++ b/Buddies/Storyboards/BuddiesStoryboard.swift
@@ -17,6 +17,7 @@ enum BuddiesStoryboard : String {
     case Profile = "Profile"
     case Discover = "Discover"
     case ViewActivity = "ViewActivity"
+    case OtherProfile = "OtherProfile"
         
     var instance: UIStoryboard {
         return UIStoryboard(name: self.rawValue, bundle: Bundle.main)

--- a/Buddies/Storyboards/OtherProfile.storyboard
+++ b/Buddies/Storyboards/OtherProfile.storyboard
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Profile-->
+        <scene sceneID="rte-GN-e6g">
+            <objects>
+                <viewController storyboardIdentifier="profileMain" title="Profile" id="gqH-7T-FDo" customClass="OtherProfileVC" customModule="Buddies" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="d61-gO-ZhA">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nsd-PI-6eI">
+                                <rect key="frame" x="20" y="40" width="157.5" height="157.5"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="UdV-am-SVz"/>
+                                    <constraint firstAttribute="width" secondItem="Nsd-PI-6eI" secondAttribute="height" multiplier="1:1" id="dop-ks-Avr"/>
+                                </constraints>
+                                <color key="tintColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <state key="normal" image="JackAndTheBeans">
+                                    <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                </state>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="----  --------  ------                         ----  -----  --------                      --------   ----- " textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="6" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="g5M-tD-eMp">
+                                <rect key="frame" x="197.5" y="76.5" width="157.5" height="54"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Favorite Topics" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Mx-Ix-Wny">
+                                <rect key="frame" x="20" y="232.5" width="183.5" height="32.5"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="27"/>
+                                <color key="textColor" red="0.36367782360000001" green="0.36367782360000001" blue="0.36367782360000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="------" lineBreakMode="tailTruncation" numberOfLines="4" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FoO-fW-uhp">
+                                <rect key="frame" x="197.5" y="40" width="157.5" height="21.5"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="18"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="85M-cq-nzf">
+                                <rect key="frame" x="20" y="285" width="335" height="100"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="KVP-fq-Jvl"/>
+                                </constraints>
+                                <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="zzx-Sa-ony">
+                                    <size key="itemSize" width="50" height="50"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells/>
+                            </collectionView>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XJX-df-EdQ">
+                                <rect key="frame" x="0.0" y="405" width="375" height="262"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            </tableView>
+                        </subviews>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="XJX-df-EdQ" secondAttribute="trailing" id="7Pn-w9-LQT"/>
+                            <constraint firstItem="85M-cq-nzf" firstAttribute="top" secondItem="3Mx-Ix-Wny" secondAttribute="bottom" constant="20" id="ILn-s5-NJZ"/>
+                            <constraint firstItem="XJX-df-EdQ" firstAttribute="top" secondItem="85M-cq-nzf" secondAttribute="bottom" constant="20" id="LK1-uy-FQh"/>
+                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="bottom" secondItem="XJX-df-EdQ" secondAttribute="bottom" id="Loh-Pq-xpw"/>
+                            <constraint firstItem="3Mx-Ix-Wny" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" constant="20" id="MSq-77-UkV"/>
+                            <constraint firstItem="g5M-tD-eMp" firstAttribute="leading" secondItem="Nsd-PI-6eI" secondAttribute="trailing" constant="20" id="P7e-Y4-noQ"/>
+                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="FoO-fW-uhp" secondAttribute="trailing" constant="20" id="S4a-5G-OTO"/>
+                            <constraint firstItem="g5M-tD-eMp" firstAttribute="top" secondItem="FoO-fW-uhp" secondAttribute="bottom" constant="15" id="Vl3-p2-vhx"/>
+                            <constraint firstItem="3Mx-Ix-Wny" firstAttribute="top" secondItem="Nsd-PI-6eI" secondAttribute="bottom" constant="35" id="bbW-T8-qZi"/>
+                            <constraint firstItem="85M-cq-nzf" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" constant="20" id="c9g-qK-1Qv"/>
+                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="85M-cq-nzf" secondAttribute="trailing" constant="20" id="cr6-d1-VcS"/>
+                            <constraint firstItem="FoO-fW-uhp" firstAttribute="width" secondItem="Nsd-PI-6eI" secondAttribute="width" id="h2w-yu-mNO"/>
+                            <constraint firstItem="Nsd-PI-6eI" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" constant="20" id="oQA-SO-9Pw"/>
+                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="g5M-tD-eMp" secondAttribute="trailing" constant="20" id="ohc-Hf-l2F"/>
+                            <constraint firstItem="Nsd-PI-6eI" firstAttribute="top" secondItem="B5B-kf-Fgn" secondAttribute="top" constant="20" id="qUa-58-aCU"/>
+                            <constraint firstItem="g5M-tD-eMp" firstAttribute="width" secondItem="Nsd-PI-6eI" secondAttribute="width" id="rEU-Do-uoE"/>
+                            <constraint firstItem="FoO-fW-uhp" firstAttribute="top" secondItem="Nsd-PI-6eI" secondAttribute="top" id="t2D-iL-2Xk"/>
+                            <constraint firstItem="XJX-df-EdQ" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" id="uNV-vI-w4i"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="B5B-kf-Fgn"/>
+                    </view>
+                    <tabBarItem key="tabBarItem" title="Profile" id="r5G-28-ixa"/>
+                    <navigationItem key="navigationItem" title="Profile" id="fiB-DG-zhD">
+                        <barButtonItem key="rightBarButtonItem" title="Settings" id="IJL-Uq-ANs"/>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="activityTable" destination="XJX-df-EdQ" id="3QW-3U-vua"/>
+                        <outlet property="bioLabel" destination="g5M-tD-eMp" id="DkJ-jz-QId"/>
+                        <outlet property="favoriteTopicsCollection" destination="85M-cq-nzf" id="ib2-oJ-E5Y"/>
+                        <outlet property="nameLabel" destination="FoO-fW-uhp" id="T9P-0p-EiB"/>
+                        <outlet property="profilePic" destination="Nsd-PI-6eI" id="d3w-xr-kEt"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MsW-tX-0vI" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="369" y="521"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="JackAndTheBeans" width="640" height="640"/>
+    </resources>
+</document>

--- a/Buddies/Storyboards/OtherProfile.storyboard
+++ b/Buddies/Storyboards/OtherProfile.storyboard
@@ -14,10 +14,14 @@
         <scene sceneID="rte-GN-e6g">
             <objects>
                 <viewController storyboardIdentifier="otherProfile" title="Profile" id="gqH-7T-FDo" customClass="OtherProfileVC" customModule="Buddies" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="d61-gO-ZhA">
+                    <view key="view" contentMode="scaleToFill" id="d61-gO-ZhA" customClass="UIScrollView">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fcj-3w-wte">
+                                <rect key="frame" x="67" y="269" width="240" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </scrollView>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nsd-PI-6eI">
                                 <rect key="frame" x="20" y="40" width="157.5" height="157.5"/>
                                 <constraints>
@@ -61,7 +65,7 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XJX-df-EdQ">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XJX-df-EdQ">
                                 <rect key="frame" x="0.0" y="443" width="355" height="224"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>

--- a/Buddies/Storyboards/OtherProfile.storyboard
+++ b/Buddies/Storyboards/OtherProfile.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="gqH-7T-FDo">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -13,7 +13,7 @@
         <!--Profile-->
         <scene sceneID="rte-GN-e6g">
             <objects>
-                <viewController storyboardIdentifier="profileMain" title="Profile" id="gqH-7T-FDo" customClass="OtherProfileVC" customModule="Buddies" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="otherProfile" title="Profile" id="gqH-7T-FDo" customClass="OtherProfileVC" customModule="Buddies" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="d61-gO-ZhA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -36,7 +36,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Favorite Topics" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Mx-Ix-Wny">
-                                <rect key="frame" x="20" y="232.5" width="183.5" height="32.5"/>
+                                <rect key="frame" x="20" y="217.5" width="183.5" height="32.5"/>
                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="27"/>
                                 <color key="textColor" red="0.36367782360000001" green="0.36367782360000001" blue="0.36367782360000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
@@ -48,7 +48,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="85M-cq-nzf">
-                                <rect key="frame" x="20" y="285" width="335" height="100"/>
+                                <rect key="frame" x="20" y="270" width="335" height="100"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="KVP-fq-Jvl"/>
@@ -62,24 +62,33 @@
                                 <cells/>
                             </collectionView>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XJX-df-EdQ">
-                                <rect key="frame" x="0.0" y="405" width="375" height="262"/>
+                                <rect key="frame" x="0.0" y="443" width="355" height="224"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Previous Activities" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C7s-eT-98e">
+                                <rect key="frame" x="20" y="390" width="335" height="33"/>
+                                <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="27"/>
+                                <color key="textColor" red="0.36367782360000001" green="0.36367782360000001" blue="0.36367782360000001" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="XJX-df-EdQ" secondAttribute="trailing" id="7Pn-w9-LQT"/>
+                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="XJX-df-EdQ" secondAttribute="trailing" constant="20" id="7Pn-w9-LQT"/>
+                            <constraint firstItem="C7s-eT-98e" firstAttribute="top" secondItem="85M-cq-nzf" secondAttribute="bottom" constant="20" id="Hms-72-nAB"/>
                             <constraint firstItem="85M-cq-nzf" firstAttribute="top" secondItem="3Mx-Ix-Wny" secondAttribute="bottom" constant="20" id="ILn-s5-NJZ"/>
-                            <constraint firstItem="XJX-df-EdQ" firstAttribute="top" secondItem="85M-cq-nzf" secondAttribute="bottom" constant="20" id="LK1-uy-FQh"/>
+                            <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="C7s-eT-98e" secondAttribute="trailing" constant="20" id="KX1-N8-pw7"/>
                             <constraint firstItem="B5B-kf-Fgn" firstAttribute="bottom" secondItem="XJX-df-EdQ" secondAttribute="bottom" id="Loh-Pq-xpw"/>
                             <constraint firstItem="3Mx-Ix-Wny" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" constant="20" id="MSq-77-UkV"/>
                             <constraint firstItem="g5M-tD-eMp" firstAttribute="leading" secondItem="Nsd-PI-6eI" secondAttribute="trailing" constant="20" id="P7e-Y4-noQ"/>
                             <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="FoO-fW-uhp" secondAttribute="trailing" constant="20" id="S4a-5G-OTO"/>
                             <constraint firstItem="g5M-tD-eMp" firstAttribute="top" secondItem="FoO-fW-uhp" secondAttribute="bottom" constant="15" id="Vl3-p2-vhx"/>
-                            <constraint firstItem="3Mx-Ix-Wny" firstAttribute="top" secondItem="Nsd-PI-6eI" secondAttribute="bottom" constant="35" id="bbW-T8-qZi"/>
+                            <constraint firstItem="3Mx-Ix-Wny" firstAttribute="top" secondItem="Nsd-PI-6eI" secondAttribute="bottom" constant="20" id="bbW-T8-qZi"/>
                             <constraint firstItem="85M-cq-nzf" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" constant="20" id="c9g-qK-1Qv"/>
                             <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="85M-cq-nzf" secondAttribute="trailing" constant="20" id="cr6-d1-VcS"/>
+                            <constraint firstItem="C7s-eT-98e" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" constant="20" id="fWb-AF-hG7"/>
                             <constraint firstItem="FoO-fW-uhp" firstAttribute="width" secondItem="Nsd-PI-6eI" secondAttribute="width" id="h2w-yu-mNO"/>
+                            <constraint firstItem="XJX-df-EdQ" firstAttribute="top" secondItem="C7s-eT-98e" secondAttribute="bottom" constant="20" id="lIF-bl-DBX"/>
                             <constraint firstItem="Nsd-PI-6eI" firstAttribute="leading" secondItem="B5B-kf-Fgn" secondAttribute="leading" constant="20" id="oQA-SO-9Pw"/>
                             <constraint firstItem="B5B-kf-Fgn" firstAttribute="trailing" secondItem="g5M-tD-eMp" secondAttribute="trailing" constant="20" id="ohc-Hf-l2F"/>
                             <constraint firstItem="Nsd-PI-6eI" firstAttribute="top" secondItem="B5B-kf-Fgn" secondAttribute="top" constant="20" id="qUa-58-aCU"/>
@@ -91,7 +100,7 @@
                     </view>
                     <tabBarItem key="tabBarItem" title="Profile" id="r5G-28-ixa"/>
                     <navigationItem key="navigationItem" title="Profile" id="fiB-DG-zhD">
-                        <barButtonItem key="rightBarButtonItem" title="Settings" id="IJL-Uq-ANs"/>
+                        <barButtonItem key="rightBarButtonItem" title="Report" id="IJL-Uq-ANs"/>
                     </navigationItem>
                     <connections>
                         <outlet property="activityTable" destination="XJX-df-EdQ" id="3QW-3U-vua"/>
@@ -99,11 +108,12 @@
                         <outlet property="favoriteTopicsCollection" destination="85M-cq-nzf" id="ib2-oJ-E5Y"/>
                         <outlet property="nameLabel" destination="FoO-fW-uhp" id="T9P-0p-EiB"/>
                         <outlet property="profilePic" destination="Nsd-PI-6eI" id="d3w-xr-kEt"/>
+                        <outlet property="reportButton" destination="IJL-Uq-ANs" id="cK4-AV-y2W"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="MsW-tX-0vI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="369" y="521"/>
+            <point key="canvasLocation" x="368.80000000000001" y="520.38980509745136"/>
         </scene>
     </scenes>
     <resources>

--- a/Buddies/Storyboards/OtherProfile.storyboard
+++ b/Buddies/Storyboards/OtherProfile.storyboard
@@ -61,7 +61,7 @@
                                 </collectionViewFlowLayout>
                                 <cells/>
                             </collectionView>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XJX-df-EdQ">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="XJX-df-EdQ">
                                 <rect key="frame" x="0.0" y="443" width="355" height="224"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>

--- a/Buddies/Storyboards/OtherProfile.storyboard
+++ b/Buddies/Storyboards/OtherProfile.storyboard
@@ -18,10 +18,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fcj-3w-wte">
-                                <rect key="frame" x="67" y="269" width="240" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </scrollView>
                             <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Nsd-PI-6eI">
                                 <rect key="frame" x="20" y="40" width="157.5" height="157.5"/>
                                 <constraints>

--- a/Buddies/Storyboards/Profile.storyboard
+++ b/Buddies/Storyboards/Profile.storyboard
@@ -29,7 +29,7 @@
         <!--Profile-->
         <scene sceneID="ged-W7-Ynx">
             <objects>
-                <viewController storyboardIdentifier="profileMain" title="Profile" id="qjg-cX-S7x" customClass="ProfileVC" customModule="Buddies" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="profileMain" title="Profile" id="qjg-cX-S7x" customClass="LoggedInProfileVC" customModule="Buddies" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="duf-QF-vs0">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Buddies/Storyboards/ViewActivity.storyboard
+++ b/Buddies/Storyboards/ViewActivity.storyboard
@@ -34,11 +34,20 @@
                     </view>
                     <connections>
                         <outlet property="contentArea" destination="gkP-p0-4aG" id="5oK-dY-hhu"/>
+                        <segue destination="DIj-N1-ehB" kind="show" identifier="showOtherUser" id="J0F-qZ-Ch5"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="74C-z0-LJt" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="416.80000000000001" y="-2678.4107946026988"/>
+        </scene>
+        <!--OtherProfile-->
+        <scene sceneID="qwd-X8-GNI">
+            <objects>
+                <viewControllerPlaceholder storyboardName="OtherProfile" id="DIj-N1-ehB" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="hwf-I0-GdP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1148" y="-2713"/>
         </scene>
     </scenes>
 </document>

--- a/Buddies/Topics/TopicStubDataSource.swift
+++ b/Buddies/Topics/TopicStubDataSource.swift
@@ -19,6 +19,12 @@ class TopicStubDataSource: NSObject, UICollectionViewDataSource {
     
     // Returns the number of topics
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        if topics.count == 0 {
+            collectionView.setEmptyMessage("No topics")
+        } else {
+            collectionView.restore()
+        }
+    
         return topics.count
     }
 

--- a/Buddies/_ThirdParty/EmptyMessageBackground.swift
+++ b/Buddies/_ThirdParty/EmptyMessageBackground.swift
@@ -1,0 +1,63 @@
+//
+//  UITableViewExt.swift
+//  Buddies
+//
+//  Created by Luke Meier on 3/26/19.
+//     from https://stackoverflow.com/questions/15746745/handling-an-empty-uitableview-print-a-friendly-message
+//
+//  Copyright © 2019 Jack and the Beans. All rights reserved.
+//
+import UIKit
+
+extension UITableView {
+    
+    func setEmptyMessage(_ message: String, font: UIFont = UIFont.systemFont(ofSize: 15)) {
+        let messageLabel = UILabel(frame: CGRect(x: 0, y: 0, width: self.bounds.size.width, height: self.bounds.size.height))
+        messageLabel.text = message
+        messageLabel.textColor = .black
+        messageLabel.numberOfLines = 0;
+        messageLabel.textAlignment = .center;
+        messageLabel.font = font
+        messageLabel.sizeToFit()
+        
+        self.backgroundView = messageLabel;
+        self.separatorStyle = .none;
+    }
+    
+    func restore() {
+        self.backgroundView = nil
+        self.separatorStyle = .singleLine
+    }
+}
+
+extension UICollectionView {
+    
+    func setEmptyMessage(_ message: String, font: UIFont = UIFont.systemFont(ofSize: 15)) {
+        let messageLabel = UILabel(frame: CGRect(x: 0, y: 0, width: self.bounds.size.width, height: self.bounds.size.height))
+        messageLabel.text = message
+        messageLabel.textColor = .black
+        messageLabel.numberOfLines = 0;
+        messageLabel.textAlignment = .center;
+        messageLabel.font = font
+        messageLabel.sizeToFit()
+        
+        self.backgroundView = messageLabel;
+    }
+    
+    func restore() {
+        self.backgroundView = nil
+    }
+}
+
+//use:
+//
+//
+//override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//    if things.count == 0 {
+//        self.tableView.setEmptyMessage("My Message")
+//    } else {
+//        self.tableView.restore()
+//    }
+//
+//    return things.count
+//}

--- a/BuddiesTests/Activities/ActivityTableVCTests.swift
+++ b/BuddiesTests/Activities/ActivityTableVCTests.swift
@@ -113,17 +113,20 @@ class ActivityTableVCTests: XCTestCase {
                                 locationText: "What up buddy",
                                 topicIds: [])
         
-        let resCell = activityTableVC.format(cell: cell, using: activity, at: IndexPath(index: 0))
         
-        XCTAssert((resCell.memberPics.filter() { $0.currentImage != nil }).isEmpty, "No user images means no UIButtons have images")
+        cell.format(using: activity, userImages: [])
         
-        XCTAssert(resCell.descriptionLabel.text == "activityDescription", "Cell Description correctly set")
         
-        XCTAssert(resCell.titleLabel.text == "activityTitle", "Cell Description correctly set")
+        XCTAssert((cell.memberPics.filter() { $0.currentImage != nil }).isEmpty, "No user images means no UIButtons have images")
         
-        XCTAssert(resCell.locationLabel.text == "What up buddy", "Cell location correctly set")
+        XCTAssert(cell.descriptionLabel.text == "activityDescription", "Cell Description correctly set")
         
-        XCTAssert(resCell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
+        XCTAssert(cell.titleLabel.text == "activityTitle", "Cell Description correctly set")
+        
+        XCTAssert(cell.locationLabel.text == "What up buddy", "Cell location correctly set")
+        
+        XCTAssert(cell
+            .extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
     }
     
     func testCellFormat_SomeImages() {
@@ -165,17 +168,17 @@ class ActivityTableVCTests: XCTestCase {
                                 locationText: "What up buddy",
                                 topicIds: [])
         
-        let resCell = activityTableVC.format(cell: cell, using: activity, at: IndexPath(index: 0))
+        cell.format(using: activity, userImages: [UIImage(), UIImage()])
         
-        XCTAssert((resCell.memberPics.filter() { $0.currentImage != nil }).count == 2, "No user images means no UIButtons have images")
+        XCTAssert((cell.memberPics.filter() { $0.currentImage != nil }).count == 2, "No user images means no UIButtons have images")
         
-        XCTAssert(resCell.descriptionLabel.text == "activityDescription", "Cell Description correctly set")
+        XCTAssert(cell.descriptionLabel.text == "activityDescription", "Cell Description correctly set")
         
-        XCTAssert(resCell.titleLabel.text == "activityTitle", "Cell Description correctly set")
+        XCTAssert(cell.titleLabel.text == "activityTitle", "Cell Description correctly set")
         
-        XCTAssert(resCell.locationLabel.text == "What up buddy", "Cell location correctly set")
+        XCTAssert(cell.locationLabel.text == "What up buddy", "Cell location correctly set")
         
-        XCTAssert(resCell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
+        XCTAssert(cell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
     }
     
     func testCellFormat_TooManyImages() {
@@ -217,17 +220,17 @@ class ActivityTableVCTests: XCTestCase {
                                 locationText: "What up buddy",
                                 topicIds: [])
         
-        let resCell = activityTableVC.format(cell: cell, using: activity, at: IndexPath(index: 0))
+        cell.format(using: activity, userImages: [UIImage(), UIImage(), UIImage()])
         
-        XCTAssert((resCell.memberPics.filter() { $0.currentImage != nil }).count == 3, "No user images means no UIButtons have images")
+        XCTAssert((cell.memberPics.filter() { $0.currentImage != nil }).count == 3, "No user images means no UIButtons have images")
         
-        XCTAssert(resCell.descriptionLabel.text == "activityDescription", "Cell Description correctly set")
+        XCTAssert(cell.descriptionLabel.text == "activityDescription", "Cell Description correctly set")
         
-        XCTAssert(resCell.titleLabel.text == "activityTitle", "Cell Description correctly set")
+        XCTAssert(cell.titleLabel.text == "activityTitle", "Cell Description correctly set")
         
-        XCTAssert(resCell.locationLabel.text == "What up buddy", "Cell location correctly set")
+        XCTAssert(cell.locationLabel.text == "What up buddy", "Cell location correctly set")
         
-        XCTAssert(!resCell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
+        XCTAssert(!cell.extraPicturesLabel.isHidden, "Cell doesn't show ellipses for extra profile images")
     }
     
     

--- a/BuddiesTests/Profile/LoggedInProfileVCTests.swift
+++ b/BuddiesTests/Profile/LoggedInProfileVCTests.swift
@@ -1,0 +1,68 @@
+//
+//  LoggedInProfileVC.swift
+//  BuddiesTests
+//
+//  Created by Luke Meier on 3/26/19.
+//  Copyright © 2019 Jack and the Beans. All rights reserved.
+//
+
+import XCTest
+
+@testable import Buddies
+
+class LoggedInProfileVCTests: XCTestCase {
+
+    var vc: LoggedInProfileVC? = LoggedInProfileVC()
+    
+    var profilePic = UIButton()
+    var bioLabel = UILabel()
+    var nameLabel = UILabel()
+    var favoriteTopicsCollection = UICollectionView(frame: CGRect(x: 0, y: 0, width: 10, height: 10), collectionViewLayout: UICollectionViewLayout())
+    
+    override func setUp() {
+        
+        vc?.dataSource = TopicStubDataSource()
+        favoriteTopicsCollection.dataSource = vc?.dataSource
+        
+        vc?.profilePic = profilePic
+        vc?.bioLabel = bioLabel
+        vc?.nameLabel = nameLabel
+        vc?.favoriteTopicsCollection = favoriteTopicsCollection
+        
+    }
+    
+    func testRender() {
+        
+        let user = OtherUser(uid: "id",
+                             imageUrl: "lolurl",
+                             dateJoined: Date(),
+                             name: "name",
+                             bio: "bio",
+                             favoriteTopics: [])
+        
+        vc?.render(with: user)
+        
+        XCTAssert(vc?.bioLabel.text == user.bio, "Bio is set correctly")
+        XCTAssert(vc?.nameLabel.text == user.name, "User's name is set correctly")
+        XCTAssert(vc?.profilePic.image(for: .normal) == nil, "No image should be loaded, since no valid url given")
+    }
+    
+    
+    func testOnImageLoad(){
+        let img = UIImage()
+        vc?.profilePic.setImage(nil, for: .normal)
+        XCTAssert(vc?.profilePic.image(for: .normal) == nil, "Initially in this test, Profile pic is nil")
+        vc?.onImageLoaded(image: img)
+        XCTAssert(vc?.profilePic.image(for: .normal) == img, "Image is set through ProfileVC's onImageLoaded")
+    }
+    
+    func testSetupDataSource(){
+        vc?.favoriteTopicsCollection.dataSource = nil
+        vc?.favoriteTopicsCollection.delegate = nil
+        vc?.setupDataSource()
+        
+        XCTAssert(vc?.favoriteTopicsCollection.dataSource != nil, "DataSource for favorite collection is set")
+        XCTAssert(vc?.favoriteTopicsCollection.delegate as? LoggedInProfileVC == vc, "DataSource for favorite collection is set")
+        XCTAssert(vc?.dataSource != nil, "VC's datasource is set")
+    }
+}

--- a/BuddiesTests/Profile/OtherProfileVCTests.swift
+++ b/BuddiesTests/Profile/OtherProfileVCTests.swift
@@ -9,13 +9,14 @@
 import XCTest
 @testable import Buddies
 
-class ProfileVCTests: XCTestCase {
+class OtherProfileVCTests: XCTestCase {
     
-    var vc: ProfileVC? = ProfileVC()
+    var vc: OtherProfileVC? = OtherProfileVC()
     
     var profilePic = UIButton()
     var bioLabel = UILabel()
     var nameLabel = UILabel()
+    var activityTable = UITableView()
     var favoriteTopicsCollection = UICollectionView(frame: CGRect(x: 0, y: 0, width: 10, height: 10), collectionViewLayout: UICollectionViewLayout())
 
     override func setUp() {
@@ -26,7 +27,9 @@ class ProfileVCTests: XCTestCase {
         vc?.profilePic = profilePic
         vc?.bioLabel = bioLabel
         vc?.nameLabel = nameLabel
+        vc?.activityTable = activityTable
         vc?.favoriteTopicsCollection = favoriteTopicsCollection
+        
     }
     
     func testRender() {
@@ -60,7 +63,7 @@ class ProfileVCTests: XCTestCase {
         vc?.setupDataSource()
         
         XCTAssert(vc?.favoriteTopicsCollection.dataSource != nil, "DataSource for favorite collection is set")
-        XCTAssert(vc?.favoriteTopicsCollection.delegate as? ProfileVC == vc, "DataSource for favorite collection is set")
+        XCTAssert(vc?.favoriteTopicsCollection.delegate as? OtherProfileVC == vc, "DataSource for favorite collection is set")
         XCTAssert(vc?.dataSource != nil, "VC's datasource is set")
     }
 

--- a/BuddiesTests/Topics/TopicLayoutTests.swift
+++ b/BuddiesTests/Topics/TopicLayoutTests.swift
@@ -178,6 +178,9 @@ class TopicLayoutTests: XCTestCase {
         
         let sameBounds = layout.shouldInvalidateLayout(forBoundsChange: initRect)
         XCTAssert(!sameBounds, "When  collectionview, invalidate if bounds")
+        
+        //to get rid of compiler warning
+        collectionView.backgroundView = nil
     }
 
 }


### PR DESCRIPTION
#### In this PR
* Click on a user icon/name to see their profile
* Other users' profiles have their last 0 to 4 previous activities, in reverse chronological order
    * They are not clickable/directly joinable, that'd be creepy.  
    * If they have no previous activities, it says "No previous activities"
* When a user has no favorited topics, it says "No Topics"
* When any activity table has no activities, it says "No results"

****

#### Notes
* At @JakeThurman and @noahtallen 's suggestion, the `OtherProfile` and `LoggedInProfile` are separate classes with a lot of overlap.  I also copied and pasted over the tests.
* If it's ok with you guys, I'll cover testing once I'm done with reporting, etc as well.
* When you click on yourself, it shows your public profile.  We will disable reporting so you cannot report yourself (for a later story)
* Profiles are not scrollable right now
* On our smallest device (5s) everything still fits fine.  
<img width="336" alt="Screen Shot 2019-03-25 at 5 44 48 PM" src="https://user-images.githubusercontent.com/7787605/55019548-803dcd00-4fcb-11e9-95f9-adafca561c87.png">

****

#### To test:
* You can get to any user in any activity by clicking 
    * Their name
    * Their profile picture
* The topics on their profile are correct
   * The topics update automatically when the user favorites/unfavorites topics
   * When no topics are favorited, it says "No topics"
* The previous activities are correct
   * There is no disclosure indicator
   * It is not clickable
   * If there are none, it says "No previous activities"
   * They are in reverse chronological order

****

Notes for testing: 
* Josh has previous activities
* Esther has no favorited topics
