### PR TITLE
Fix #124

### DIFF
--- a/Buddies.xcodeproj/project.pbxproj
+++ b/Buddies.xcodeproj/project.pbxproj
@@ -24,7 +24,7 @@
 		45FED0AF220A657100B90C3B /* DeleteAccountVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FED0AE220A657100B90C3B /* DeleteAccountVC.swift */; };
 		5802266A220BE5E90068E08E /* ToggleButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58022669220BE5E90068E08E /* ToggleButton.swift */; };
 		5802266F220CC1210068E08E /* ToggleButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5802266E220CC1210068E08E /* ToggleButtonTests.swift */; };
-		5811D8E62252D5D1002D2166 /* BuddiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5811D8E52252D5D1002D2166 /* BuddiesTests.swift */; };
+		5811D8E62252D5D1002D2166 /* BuddiesUITestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5811D8E52252D5D1002D2166 /* BuddiesUITestCase.swift */; };
 		5811D8E82252D82A002D2166 /* TestReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5811D8E72252D82A002D2166 /* TestReport.swift */; };
 		5811D8EE2252E928002D2166 /* GoogleService-Info-Dev.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5811D8EC2252E3DB002D2166 /* GoogleService-Info-Dev.plist */; };
 		5811D8EF2252E929002D2166 /* GoogleService-Info-Dev.plist in Resources */ = {isa = PBXBuildFile; fileRef = 5811D8EC2252E3DB002D2166 /* GoogleService-Info-Dev.plist */; };
@@ -57,6 +57,7 @@
 		58B42611221CE7EE000ACB28 /* TopicActivityTableVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */; };
 		58DA53292254ECB500A604DE /* TestTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DA53282254ECB500A604DE /* TestTabBar.swift */; };
 		58DA532B2254F98C00A604DE /* TestProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DA532A2254F98C00A604DE /* TestProfile.swift */; };
+		58DA532D22551E6400A604DE /* TestCreateActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DA532C22551E6400A604DE /* TestCreateActivity.swift */; };
 		58DBF760221CB7B3008512B3 /* ActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75E221CB7B3008512B3 /* ActivityTests.swift */; };
 		58DBF761221CB7B3008512B3 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DBF75F221CB7B3008512B3 /* UserTests.swift */; };
 		58E1BF8B224EA12F00C7A8E4 /* ReportModalVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58E1BF8A224EA12E00C7A8E4 /* ReportModalVC.swift */; };
@@ -175,7 +176,7 @@
 		45FED0AE220A657100B90C3B /* DeleteAccountVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteAccountVC.swift; sourceTree = "<group>"; };
 		58022669220BE5E90068E08E /* ToggleButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleButton.swift; sourceTree = "<group>"; };
 		5802266E220CC1210068E08E /* ToggleButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToggleButtonTests.swift; sourceTree = "<group>"; };
-		5811D8E52252D5D1002D2166 /* BuddiesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddiesTests.swift; sourceTree = "<group>"; };
+		5811D8E52252D5D1002D2166 /* BuddiesUITestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BuddiesUITestCase.swift; sourceTree = "<group>"; };
 		5811D8E72252D82A002D2166 /* TestReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestReport.swift; sourceTree = "<group>"; };
 		5811D8EC2252E3DB002D2166 /* GoogleService-Info-Dev.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info-Dev.plist"; sourceTree = "<group>"; };
 		5811D8F22252EE8E002D2166 /* MockLocation.gpx */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = MockLocation.gpx; sourceTree = "<group>"; };
@@ -207,6 +208,7 @@
 		58B42610221CE7EE000ACB28 /* TopicActivityTableVC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicActivityTableVC.swift; sourceTree = "<group>"; };
 		58DA53282254ECB500A604DE /* TestTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestTabBar.swift; sourceTree = "<group>"; };
 		58DA532A2254F98C00A604DE /* TestProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestProfile.swift; sourceTree = "<group>"; };
+		58DA532C22551E6400A604DE /* TestCreateActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestCreateActivity.swift; sourceTree = "<group>"; };
 		58DBF75E221CB7B3008512B3 /* ActivityTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityTests.swift; sourceTree = "<group>"; };
 		58DBF75F221CB7B3008512B3 /* UserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		58E1BF8A224EA12E00C7A8E4 /* ReportModalVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReportModalVC.swift; sourceTree = "<group>"; };
@@ -653,12 +655,13 @@
 			isa = PBXGroup;
 			children = (
 				B63D444922417DC600612239 /* TestOnboarding.swift */,
-				5811D8E52252D5D1002D2166 /* BuddiesTests.swift */,
+				5811D8E52252D5D1002D2166 /* BuddiesUITestCase.swift */,
 				B63D444B22417DC600612239 /* Info.plist */,
 				5811D8E72252D82A002D2166 /* TestReport.swift */,
 				5811D8F22252EE8E002D2166 /* MockLocation.gpx */,
 				58DA53282254ECB500A604DE /* TestTabBar.swift */,
 				58DA532A2254F98C00A604DE /* TestProfile.swift */,
+				58DA532C22551E6400A604DE /* TestCreateActivity.swift */,
 			);
 			path = BuddiesUITests;
 			sourceTree = "<group>";
@@ -1008,9 +1011,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				B63D444A22417DC600612239 /* TestOnboarding.swift in Sources */,
-				5811D8E62252D5D1002D2166 /* BuddiesTests.swift in Sources */,
+				5811D8E62252D5D1002D2166 /* BuddiesUITestCase.swift in Sources */,
 				5811D8E82252D82A002D2166 /* TestReport.swift in Sources */,
 				58DA53292254ECB500A604DE /* TestTabBar.swift in Sources */,
+				58DA532D22551E6400A604DE /* TestCreateActivity.swift in Sources */,
 				58DA532B2254F98C00A604DE /* TestProfile.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Buddies/Controls/FAB.swift
+++ b/Buddies/Controls/FAB.swift
@@ -18,6 +18,7 @@ class FAB {
     init(for vc: UIViewController) {
         self.vc = vc
         self.button = MDCFloatingButton()
+        self.button.accessibilityIdentifier = "FAB"
     }
     
     func renderCreateActivityFab() {

--- a/Buddies/CreateActivity/CreateActivityVC.swift
+++ b/Buddies/CreateActivity/CreateActivityVC.swift
@@ -174,6 +174,12 @@ class CreateActivityVC: UITableViewController, UITextViewDelegate, UITextFieldDe
 
         descriptionTextView.delegate = self
         descriptionTextView.textColor = UIColor.lightGray
+        
+        descriptionTextView.accessibilityIdentifier = "activityDescriptionField"
+        locationField.accessibilityIdentifier = "activityLocationField"
+        titleField.accessibilityIdentifier = "activityTitleField"
+        
+        
         self.setupHideKeyboardOnTap()
         configureSearchTextField()
         

--- a/Buddies/Storyboards/CreateActivity.storyboard
+++ b/Buddies/Storyboards/CreateActivity.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wcw-8e-tUa">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wcw-8e-tUa">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -29,6 +29,7 @@
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="a3a-rU-EbY">
                                                     <rect key="frame" x="15" y="15" width="350" height="22.5"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="activityTitleField"/>
                                                     <nil key="textColor"/>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                                     <textInputTraits key="textInputTraits"/>
@@ -51,6 +52,7 @@
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder=" Location" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="R3p-kv-sml" customClass="SearchTextField" customModule="Buddies" customModuleProvider="target">
                                                     <rect key="frame" x="15" y="5" width="345" height="37.5"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="activityLocationField"/>
                                                     <nil key="textColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                     <textInputTraits key="textInputTraits"/>
@@ -81,6 +83,7 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5dM-55-XRr" customClass="RangeSeekSlider" customModule="Buddies" customModuleProvider="target">
                                                     <rect key="frame" x="15" y="15" width="345" height="39.5"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="activityDaterangeSlider"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="number" keyPath="minValue">
                                                             <real key="value" value="1"/>
@@ -168,6 +171,9 @@
                                                 </label>
                                             </subviews>
                                         </tableViewCellContentView>
+                                        <accessibility key="accessibilityConfiguration" identifier="activityPickTopics">
+                                            <bool key="isElement" value="YES"/>
+                                        </accessibility>
                                         <connections>
                                             <segue destination="hGH-hg-T4g" kind="show" id="kes-pp-8a4"/>
                                         </connections>
@@ -182,6 +188,7 @@
                                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Description" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="yEs-Fb-whx">
                                                     <rect key="frame" x="16" y="11" width="343" height="284"/>
                                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="activityDescriptionField"/>
                                                     <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/BuddiesUITests/BuddiesUITestCase.swift
+++ b/BuddiesUITests/BuddiesUITestCase.swift
@@ -8,7 +8,6 @@
 
 import XCTest
 
-
 extension XCUIElement {
     var hasFocus: Bool {
         let hasKeyboardFocus = (self.value(forKey: "hasKeyboardFocus") as? Bool) ?? false
@@ -36,7 +35,7 @@ class BuddiesUITest: XCTestCase {
         let result = XCTWaiter().wait(for: [expectation], timeout: timeout)
         return result == .completed
     }
-    
+
     func login(){
         app.buttons["haveAccount"].tap()
         

--- a/BuddiesUITests/BuddiesUITestCase.swift
+++ b/BuddiesUITests/BuddiesUITestCase.swift
@@ -15,7 +15,7 @@ extension XCUIElement {
     }
 }
 
-class BuddiesUITest: XCTestCase {
+class BuddiesUITestCase: XCTestCase {
     var app: XCUIApplication!
     
     override func setUp() {

--- a/BuddiesUITests/TestCreateActivity.swift
+++ b/BuddiesUITests/TestCreateActivity.swift
@@ -1,0 +1,34 @@
+//
+//  TestCreateActivity.swift
+//  BuddiesUITests
+//
+//  Created by Luke Meier on 4/3/19.
+//  Copyright © 2019 Jack and the Beans. All rights reserved.
+//
+
+import XCTest
+
+class TestCreateActivity: XCTestCase {
+
+    override func setUp() {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+        XCUIApplication().launch()
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+}

--- a/BuddiesUITests/TestCreateActivity.swift
+++ b/BuddiesUITests/TestCreateActivity.swift
@@ -8,27 +8,68 @@
 
 import XCTest
 
-class TestCreateActivity: XCTestCase {
+class TestCreateActivity: BuddiesUITestCase {
 
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-
-        // In UI tests it is usually best to stop immediately when a failure occurs.
-        continueAfterFailure = false
-
-        // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-        XCUIApplication().launch()
-
-        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    func trySuggest(shouldAlert: Bool = true, extraMsg: String = ""){
+        let suggestButton = app.navigationBars["Suggest Activity"].buttons["Suggest"]
+        
+        XCTAssertTrue(waitForElementToAppear(suggestButton, timeout: 5), "Suggest button should exist. \(extraMsg)")
+        
+        suggestButton.tap()
+        
+        let okButton = app.alerts["Missing information"].buttons["OK"]
+        
+        XCTAssert(waitForElementToAppear(okButton, timeout: 5) == shouldAlert, "Alert should \(shouldAlert ? "" : "not") appear when suggesting. \(extraMsg)")
+        
+        if shouldAlert {
+            okButton.tap()
+        }
     }
+    
+    func testCreateActivity() {
+        login()
+        
+        let tablesQuery = app.tables
+        
+        tablesQuery/*@START_MENU_TOKEN@*/.buttons["FAB"]/*[[".buttons[\"plus\"]",".buttons[\"FAB\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        
+        trySuggest(shouldAlert: true, extraMsg: "Inititally on an empty table")
+        
+        let title = tablesQuery.textFields["activityTitleField"]
+        title.tap()
+        title.typeText("Title")
+        
+        trySuggest(shouldAlert: true, extraMsg: "After typing title...")
+        
+        let locationTextField = tablesQuery.textFields["activityLocationField"]
+        locationTextField.tap()
+        locationTextField.typeText("Beans")
+        
+        trySuggest(shouldAlert: true, extraMsg: "After writing a location...")
+        
+        
+        let description = tablesQuery/*@START_MENU_TOKEN@*/.textViews["activityDescriptionField"]/*[[".cells.textViews[\"activityDescriptionField\"]",".textViews[\"activityDescriptionField\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        description.tap()
+        
+        trySuggest(shouldAlert: true, extraMsg: "After tapping description...")
+        
+        description.tap()
+        description.typeText("Description")
+        
+        print(app.debugDescription)
+        
+        let pickTopics = tablesQuery.cells["activityPickTopics"]
+        pickTopics.tap()
+        
+        let collectionViewsQuery = app.collectionViews
+        collectionViewsQuery.children(matching: .cell).element(boundBy: 1).buttons["uncheck circle"].tap()
+    
+        app.navigationBars["Pick Topics"].buttons["Done"].tap()
+        
+        trySuggest(shouldAlert: true, extraMsg: "After adding topics...")
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() {
-        // Use recording to get started writing UI tests.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        
+        //Doesn't actually create one
     }
 
 }

--- a/BuddiesUITests/TestOnboarding.swift
+++ b/BuddiesUITests/TestOnboarding.swift
@@ -20,7 +20,7 @@ extension XCUIApplication {
     }
 }
 
-class TestOnboarding: BuddiesUITest {
+class TestOnboarding: BuddiesUITestCase {
     func testLoginBase () {
         XCTAssertTrue(app.isDisplayingLoginBase)
         XCTAssertFalse(app.isDisplayingLoginExisting)

--- a/BuddiesUITests/TestProfile.swift
+++ b/BuddiesUITests/TestProfile.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 
-class TestProfile: BuddiesUITest {
+class TestProfile: BuddiesUITestCase {
 
     func testEditProfile() {
         login()

--- a/BuddiesUITests/TestReport.swift
+++ b/BuddiesUITests/TestReport.swift
@@ -8,9 +8,9 @@
 
 import XCTest
 
-class TestReport: BuddiesUITest {
+class TestReport: BuddiesUITestCase {
     func testReportButton() {
-        self.login()
+        login()
     
         let topCell = app.tables/*@START_MENU_TOKEN@*/.cells["activityCell0.0"]/*[[".cells[\"hfdg, Hey, London, PA, United States, Through Tomorrow\"]",".cells[\"activityCell0.0\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
         XCTAssertTrue(waitForElementToAppear(topCell, timeout: 30), "top activity cell never appeared (30 second timeout)")

--- a/BuddiesUITests/TestTabBar.swift
+++ b/BuddiesUITests/TestTabBar.swift
@@ -14,7 +14,7 @@ extension XCUIApplication {
     }
 }
 
-class TestTabBar: BuddiesUITest {
+class TestTabBar: BuddiesUITestCase {
     func testAllTabBarButtons() {
         login()
         


### PR DESCRIPTION
* Resolves #124 
   * Shows _all_ missing fields in each alert.  It used to just display one (sometimes.  It also sometimes just did nothing/crashed).   
* Adds a UITest for Create Activity

To test:
* Is there any way you can omit a field in Create Activity that causes a fatal error?  If not, we gucci.