### PR TITLE
Topic Text fix

### DIFF
--- a/Buddies/Info.plist
+++ b/Buddies/Info.plist
@@ -58,8 +58,6 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>

--- a/Buddies/Storyboards/PickTopics.storyboard
+++ b/Buddies/Storyboards/PickTopics.storyboard
@@ -37,8 +37,8 @@
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="08U-5Q-pJD">
                                                     <rect key="frame" x="0.0" y="109" width="180" height="50"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Caption" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="shh-TG-IEz">
-                                                            <rect key="frame" x="8" y="19" width="59" height="22"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Caption" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="shh-TG-IEz">
+                                                            <rect key="frame" x="8" y="19" width="138" height="22"/>
                                                             <fontDescription key="fontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="16"/>
                                                             <color key="textColor" red="0.27058823529999998" green="0.2666666667" blue="0.72156862749999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -73,6 +73,7 @@
                                                         <constraint firstItem="SrS-2P-gga" firstAttribute="centerY" secondItem="08U-5Q-pJD" secondAttribute="centerY" constant="4.5" id="Ei3-YD-qXo"/>
                                                         <constraint firstAttribute="trailing" secondItem="SrS-2P-gga" secondAttribute="trailing" constant="-6" id="ROr-Lo-ctC"/>
                                                         <constraint firstAttribute="height" constant="50" id="uBn-OJ-1Of"/>
+                                                        <constraint firstItem="SrS-2P-gga" firstAttribute="leading" secondItem="shh-TG-IEz" secondAttribute="trailing" constant="-16" id="xru-bw-XVe"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>

--- a/Buddies/Storyboards/Topics.storyboard
+++ b/Buddies/Storyboards/Topics.storyboard
@@ -59,8 +59,8 @@
                                                                 <action selector="toggleSelected:" destination="Zc6-W6-bDA" eventType="touchUpInside" id="B4v-q2-J1J"/>
                                                             </connections>
                                                         </button>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Caption" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9F7-fL-Jk5">
-                                                            <rect key="frame" x="8" y="19" width="59" height="22"/>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Caption" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="14" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9F7-fL-Jk5">
+                                                            <rect key="frame" x="8" y="19" width="138" height="22"/>
                                                             <fontDescription key="fontDescription" name="AvenirNext-DemiBold" family="Avenir Next" pointSize="16"/>
                                                             <color key="textColor" red="0.27058823529999998" green="0.2666666667" blue="0.72156862749999995" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -72,6 +72,7 @@
                                                         <constraint firstItem="9F7-fL-Jk5" firstAttribute="centerY" secondItem="Xh3-Aa-hsf" secondAttribute="centerY" constant="5" id="Tme-Ls-r8H"/>
                                                         <constraint firstItem="lNO-2G-fTv" firstAttribute="centerY" secondItem="Xh3-Aa-hsf" secondAttribute="centerY" constant="3" id="ZWx-OX-3Mb"/>
                                                         <constraint firstAttribute="height" constant="50" id="dcU-8U-2z0"/>
+                                                        <constraint firstItem="lNO-2G-fTv" firstAttribute="leading" secondItem="9F7-fL-Jk5" secondAttribute="trailing" constant="-16" id="hRo-O4-w94"/>
                                                         <constraint firstAttribute="trailing" secondItem="lNO-2G-fTv" secondAttribute="trailing" constant="-6" id="j9j-ok-kKL"/>
                                                     </constraints>
                                                 </view>

--- a/Buddies/Topics/TopicLayout.swift
+++ b/Buddies/Topics/TopicLayout.swift
@@ -32,9 +32,10 @@ import UIKit
 
 class TopicLayout: UICollectionViewLayout {
 
-    let topicWidth: CGFloat = 150
-    let heightToWidthRatio: CGFloat = 1
+    let topicWidth: CGFloat = 130
+    let heightToWidthRatio: CGFloat = 0.8
     var cellPadding: CGFloat = 6
+    let maxCols = 4
     
     func xOffsets(for cols: Int, ofSize width: CGFloat) -> [CGFloat] {
         return (0 ..< cols).map { width * CGFloat($0) }
@@ -57,7 +58,7 @@ class TopicLayout: UICollectionViewLayout {
     
     var numberOfColumns: Int {
         get {
-            return Int(floor(contentWidth / (topicWidth + 2*cellPadding)))
+            return min(Int(floor(contentWidth / (topicWidth + 2*cellPadding))), maxCols)
         }
     }
 
@@ -112,7 +113,7 @@ class TopicLayout: UICollectionViewLayout {
             return
         }
         
-        let height = cellHeight(relativeTo: topicWidth, ratio: heightToWidthRatio, padding: cellPadding)
+        let height = cellHeight(relativeTo: columnWidth, ratio: heightToWidthRatio, padding: cellPadding)
         
         let (maxRow, _) = getCoords(item: collectionView.numberOfItems(inSection: 0))
 

--- a/Buddies/Topics/TopicTabVC.swift
+++ b/Buddies/Topics/TopicTabVC.swift
@@ -60,4 +60,9 @@ class TopicTabVC: TopicsVC, TopicCollectionDelegate {
             self.collectionView.reloadData()
         }
     }
+    
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        return
+    }
+            
 }

--- a/Buddies/Topics/TopicsVC.swift
+++ b/Buddies/Topics/TopicsVC.swift
@@ -17,7 +17,7 @@ class TopicsVC: UICollectionViewController {
     
     var selectedTopics = [Topic]()
 
-      
+    
     @IBAction func toggleSelected(_ sender: ToggleButton) {
         guard let cell = sender.superview?.superview?.superview?.superview as? TopicCell,
             let topic = cell.topic else { return }
@@ -57,6 +57,15 @@ class TopicsVC: UICollectionViewController {
         }
     
         return cell
+    }
+    
+    override func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let cell = collectionView.cellForItem(at: indexPath) as? TopicCell,
+            let topic = cell.topic else { return }
+        
+        cell.toggleButton.toggle()
+        let selected = cell.toggleButton.isSelected
+        changeSelectedState(for: topic, isSelected: selected)
     }
 }
 

--- a/BuddiesUITests/TestCreateActivity.swift
+++ b/BuddiesUITests/TestCreateActivity.swift
@@ -31,7 +31,11 @@ class TestCreateActivity: BuddiesUITestCase {
         
         let tablesQuery = app.tables
         
-        tablesQuery/*@START_MENU_TOKEN@*/.buttons["FAB"]/*[[".buttons[\"plus\"]",".buttons[\"FAB\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        let fab = tablesQuery/*@START_MENU_TOKEN@*/.buttons["FAB"]/*[[".buttons[\"plus\"]",".buttons[\"FAB\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/
+        
+        XCTAssertTrue(waitForElementToAppear(fab, timeout: 10), "Fab never loads")
+        
+        fab.tap()
         
         trySuggest(shouldAlert: true, extraMsg: "Inititally on an empty table")
         


### PR DESCRIPTION
* Resolves #76 
* Handles that thing where people want to select the WHOLE topic field to select topics for Create Activities
* Now 5s devices have two columns of topics and iPads have max 4 columns
* Now iPads won't rotate

To test:
* Is there no overlap for topic text and buttons
* Pick Topics in `CreateActivity` and then tap any area other than the circular button.  