### PR TITLE
BUD-146 block users

### DIFF
--- a/Buddies/Activities/ActivityTableVC.swift
+++ b/Buddies/Activities/ActivityTableVC.swift
@@ -102,7 +102,7 @@ class ActivityTableVC: UITableViewController, FilterSearchBarDelegate, ActivityT
     // MARK:- Table view data source
     func updateActivityInSection(activity: Activity, section: Int) {
         if let path = dataSource.updateActivityInSection(activity: activity, section: section) {
-            tableView.reloadRows(at: [path], with: .fade)
+            tableView.reloadRows(at: [path], with: .none)
         }
     }
     

--- a/Buddies/Activities/View Activity/ViewActivityController.swift
+++ b/Buddies/Activities/View Activity/ViewActivityController.swift
@@ -137,7 +137,7 @@ class ViewActivityController: UIViewController {
         showCancelableAlert(withMsg: "Are you sure you want to remove this user?", withTitle: "Remove User", withAction: "Remove") { didConfirm, msg in
             guard didConfirm,
                 let activity = self.curActivity else { return }
-            activity.removeMember(with: uid)
+            activity.banUser(with: uid)
         }
     }
     

--- a/Buddies/Activities/View Activity/ViewActivityController.swift
+++ b/Buddies/Activities/View Activity/ViewActivityController.swift
@@ -37,7 +37,6 @@ class ViewActivityController: UIViewController {
     
     /// Required for the `MessageInputBar` to be visible
     override var canBecomeFirstResponder: Bool {
-        
         let status = curMemberStatus ?? .none
         if status == . none {
             return false

--- a/Buddies/Activities/View Activity/ViewActivityController.swift
+++ b/Buddies/Activities/View Activity/ViewActivityController.swift
@@ -25,6 +25,9 @@ class ViewActivityController: UIViewController {
     private var descriptionView: UIView?
     @IBOutlet weak var contentArea: UIView! // We render EVERYTHING inside this.
 
+    // For the "you can't see this" message
+    @IBOutlet weak var errorText: UILabel!
+    
     // MARK: Activity specific data which is refreshed by the updater:
     private var curActivity: Activity?
     private var curMemberStatus: MemberStatus?
@@ -61,6 +64,7 @@ class ViewActivityController: UIViewController {
     // Programmatically setup nav bar:
     override func viewDidLoad() {
         self.title = "View Activity"
+        self.errorText.isHidden = true
         //contentArea.becomeFirstResponder()
         reportButton = UIBarButtonItem(title: "Report", style: .plain, target: self, action: #selector(self.onReportTap(_:)))
         editButton = UIBarButtonItem(title: "Edit", style: .plain, target: self, action: #selector(self.onEditTap))
@@ -211,7 +215,6 @@ class ViewActivityController: UIViewController {
             } else {
                 // It has been deleted
                 self.stopListeningToActivity?()
-                self.goBack()
             }
         }
     }
@@ -253,6 +256,12 @@ class ViewActivityController: UIViewController {
     func render() {
         // Do not render until view has mounted:
         guard viewHasMounted else { return }
+
+        if (curActivity == nil) {
+            self.errorText.isHidden = false
+        } else {
+            self.errorText.isHidden = true
+        }
 
         // Do not render until data exists:
         guard let activity = self.curActivity,

--- a/Buddies/Controls/ReportModalVC.swift
+++ b/Buddies/Controls/ReportModalVC.swift
@@ -94,8 +94,8 @@ class ReportModalVC: UIViewController, UITextViewDelegate {
         //Quotes if mentioning an activity
         let quote = isUser ? "" : "\""
         let nameText = "\(quote)\(name ?? "this")\(quote)"
-        
-        warningText.text = "By reporting \(nameText), you block \(pronoun)."
+        let blockInfoText = isUser ? " You'll be removed from all activities you share, and you won't be able to see activities they're in." : ""
+        warningText.text = "By reporting \(nameText), you block \(pronoun).\(blockInfoText)"
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Buddies/Models/Activity.swift
+++ b/Buddies/Models/Activity.swift
@@ -22,7 +22,7 @@ enum MemberStatus {
     case none
 }
 
-class Activity {
+class Activity: Equatable {
     let delegate: ActivityInvalidationDelegate?
     
     // MARK: Immutable properties
@@ -108,6 +108,30 @@ class Activity {
                         endTime: endTime,
                         locationText: locationText,
                         topicIds: topicIds)
+    }
+
+    static func == (lhs: Activity, rhs: Activity) -> Bool {
+        return
+            lhs.activityId == rhs.activityId &&
+            lhs.title == rhs.title &&
+            lhs.description == rhs.description &&
+            lhs.members == rhs.members &&
+            lhs.topicIds == rhs.topicIds &&
+            lhs.location == rhs.location &&
+            lhs.locationText == rhs.locationText &&
+            lhs.startTime == rhs.startTime &&
+            lhs.endTime == rhs.endTime &&
+            lhs.areUsersEqual(to: rhs.users)
+    }
+    
+    func areUsersEqual(to otherUsers: [User]) -> Bool {
+        for user in users {
+            // See if the user exists anywhere in the other array. We only
+            guard let _ = otherUsers.firstIndex(where: { $0.isEqual(to: user) }) else {
+                return false
+            }
+        }
+        return true
     }
 
     func getMemberStatus(of userId: String) -> MemberStatus {

--- a/Buddies/Models/Activity.swift
+++ b/Buddies/Models/Activity.swift
@@ -132,8 +132,12 @@ class Activity: Equatable {
     }
     
     func areUsersEqual(to otherUsers: [User]) -> Bool {
+        if self.users.count != otherUsers.count {
+            return false
+        }
         for user in users {
-            // See if the user exists anywhere in the other array. We only
+            // See if the user exists anywhere in the other array.
+            // Return false if the user does not exist:
             guard let _ = otherUsers.firstIndex(where: { $0.isEqual(to: user) }) else {
                 return false
             }

--- a/Buddies/Models/User.swift
+++ b/Buddies/Models/User.swift
@@ -147,11 +147,14 @@ class LoggedInUser : User, Equatable {
 
     func isBlocked(user: UserId?) -> Bool {
         guard let user = user else { return false }
-        return blockedUsers.contains(user) || blockedBy.contains(user)
+        return userBlockList.contains(user)
     }
 
     func isBlocked(activity: Activity?) -> Bool {
         guard let activity = activity else { return false }
+        if activity.getMemberStatus(of: self.uid) == .banned {
+            return true
+        }
         if blockedActivities.contains(activity.activityId) {
             return true
         }

--- a/Buddies/Models/User.swift
+++ b/Buddies/Models/User.swift
@@ -127,6 +127,36 @@ class LoggedInUser : User {
     var blockedActivities : [ActivityId] { didSet { onChange("blocked_activities", oldValue, blockedActivities) } }
     let blockedBy : [UserId] // Shouldn't be updated directly! Automatic inverse of blocked_users.
     
+    func isBlocked(user: UserId?) -> Bool {
+        guard let user = user else { return false }
+        return blockedUsers.contains(user) || blockedBy.contains(user)
+    }
+
+    func isBlocked(activity: Activity?) -> Bool {
+        guard let activity = activity else { return false }
+        if blockedActivities.contains(activity.activityId) {
+            return true
+        }
+        for id in activity.members {
+            if (isBlocked(user: id)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    func isUserBlockListDifferent(_ newUser: LoggedInUser) -> Bool {
+        let oldList = Set(blockedUsers + blockedBy)
+        let newList = Set(newUser.blockedUsers + newUser.blockedBy)
+        return oldList == newList
+    }
+    
+    func isActivityBlockListDifferent(_ newUser: LoggedInUser) -> Bool {
+        let oldList = Set(blockedActivities)
+        let newList = Set(newUser.blockedActivities)
+        return oldList == newList
+    }
+
     // map of activity ID to timestamp - when the user last read the chat.
     var chatReadAt: [ ActivityId: Timestamp ] { didSet { onChange("chat_read_at", oldValue, chatReadAt) } }
     

--- a/Buddies/Models/User.swift
+++ b/Buddies/Models/User.swift
@@ -25,9 +25,10 @@ protocol User {
     var name: String { get }
     var bio: String { get }
     var favoriteTopics: [String] { get }
+    func isEqual(to user: User) -> Bool
 }
 
-class OtherUser : User {
+class OtherUser : User, Equatable {
     let uid: UserId
     var image: UIImage?
     let imageUrl: String
@@ -74,9 +75,22 @@ class OtherUser : User {
                          bio: bio,
                          favoriteTopics: favoriteTopics)
     }
+
+    func isEqual(to user: User) -> Bool {
+        return self.uid == user.uid &&
+            self.name == user.name &&
+            self.bio == user.bio &&
+            self.imageVersion == user.imageVersion &&
+            self.image == user.image &&
+            self.favoriteTopics == user.favoriteTopics
+    }
+
+    static func == (lhs: OtherUser, rhs: OtherUser) -> Bool {
+        return lhs.isEqual(to: rhs)
+    }
 }
 
-class LoggedInUser : User {
+class LoggedInUser : User, Equatable {
     
     let delegate: LoggedInUserInvalidationDelegate?
     
@@ -252,5 +266,30 @@ class LoggedInUser : User {
                     filterSettings: data["filter_settings"] as? [String:Int] ?? FilterSearchBar.defaultSettings,
                     notificationToken: data["notification_token"] as? String,
                     chatReadAt: chatReadAt)
+    }
+
+    func isEqual(to user: User) -> Bool {
+        return self.uid == user.uid &&
+            self.name == user.name &&
+            self.bio == user.bio &&
+            self.imageVersion == user.imageVersion &&
+            self.image == user.image &&
+            self.favoriteTopics == user.favoriteTopics
+    }
+
+    static func == (lhs: LoggedInUser, rhs: LoggedInUser) -> Bool {
+        return lhs.isEqual(to: rhs) &&
+            lhs.email == rhs.email &&
+            lhs.facebookId == rhs.facebookId &&
+            lhs.favoriteTopics == rhs.favoriteTopics &&
+            lhs.isAdmin == rhs.isAdmin &&
+            lhs.blockedUsers == rhs.blockedUsers &&
+            lhs.blockedBy == rhs.blockedBy &&
+            lhs.blockedActivities == rhs.blockedActivities &&
+            lhs.location == rhs.location &&
+            lhs.shouldSendJoinedActivityNotification == rhs.shouldSendJoinedActivityNotification &&
+            lhs.shouldSendActivitySuggestionNotification == rhs.shouldSendActivitySuggestionNotification &&
+            lhs.filterSettings == rhs.filterSettings &&
+            lhs.notificationToken == rhs.notificationToken
     }
 }

--- a/Buddies/Models/User.swift
+++ b/Buddies/Models/User.swift
@@ -141,6 +141,10 @@ class LoggedInUser : User, Equatable {
     var blockedActivities : [ActivityId] { didSet { onChange("blocked_activities", oldValue, blockedActivities) } }
     let blockedBy : [UserId] // Shouldn't be updated directly! Automatic inverse of blocked_users.
     
+    var userBlockList: [UserId] {
+        return blockedUsers + blockedBy
+    }
+
     func isBlocked(user: UserId?) -> Bool {
         guard let user = user else { return false }
         return blockedUsers.contains(user) || blockedBy.contains(user)
@@ -159,16 +163,25 @@ class LoggedInUser : User, Equatable {
         return false
     }
 
-    func isUserBlockListDifferent(_ newUser: LoggedInUser) -> Bool {
-        let oldList = Set(blockedUsers + blockedBy)
-        let newList = Set(newUser.blockedUsers + newUser.blockedBy)
-        return oldList != newList
+    func isUserBlockListDifferent(_ newUser: LoggedInUser?) -> Bool {
+        if let newUser = newUser {
+            let oldList = Set(blockedUsers + blockedBy)
+            let newList = Set(newUser.blockedUsers + newUser.blockedBy)
+            return oldList != newList
+        } else {
+            let numBlocked = self.blockedUsers.count + self.blockedBy.count
+            return numBlocked > 0
+        }
     }
     
-    func isActivityBlockListDifferent(_ newUser: LoggedInUser) -> Bool {
-        let oldList = Set(blockedActivities)
-        let newList = Set(newUser.blockedActivities)
-        return oldList != newList
+    func isActivityBlockListDifferent(_ newUser: LoggedInUser?) -> Bool {
+        if let newUser = newUser {
+            let oldList = Set(blockedActivities)
+            let newList = Set(newUser.blockedActivities)
+            return oldList != newList
+        } else {
+            return self.blockedActivities.count > 0
+        }
     }
 
     // map of activity ID to timestamp - when the user last read the chat.

--- a/Buddies/Models/User.swift
+++ b/Buddies/Models/User.swift
@@ -162,13 +162,13 @@ class LoggedInUser : User, Equatable {
     func isUserBlockListDifferent(_ newUser: LoggedInUser) -> Bool {
         let oldList = Set(blockedUsers + blockedBy)
         let newList = Set(newUser.blockedUsers + newUser.blockedBy)
-        return oldList == newList
+        return oldList != newList
     }
     
     func isActivityBlockListDifferent(_ newUser: LoggedInUser) -> Bool {
         let oldList = Set(blockedActivities)
         let newList = Set(newUser.blockedActivities)
-        return oldList == newList
+        return oldList != newList
     }
 
     // map of activity ID to timestamp - when the user last read the chat.

--- a/Buddies/Storyboards/Profile.storyboard
+++ b/Buddies/Storyboards/Profile.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RzU-fB-0hD">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="RzU-fB-0hD">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -223,21 +223,21 @@
                         <sections>
                             <tableViewSection headerTitle="Notifications" id="1g5-ZM-3mS">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="60" id="oGD-rH-L1b">
-                                        <rect key="frame" x="0.0" y="55.5" width="375" height="60"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="50" id="oGD-rH-L1b">
+                                        <rect key="frame" x="0.0" y="55.5" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oGD-rH-L1b" id="JPd-zT-r0Z">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="59.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="49.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Activities in Starred Topics" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qgC-H0-V7s">
-                                                    <rect key="frame" x="26" y="21" width="265" height="18"/>
+                                                    <rect key="frame" x="26" y="16" width="265" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2my-lj-ZcM">
-                                                    <rect key="frame" x="301" y="14.5" width="51" height="31"/>
+                                                    <rect key="frame" x="301" y="9.5" width="51" height="31"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="b4D-a6-Xfs"/>
                                                     </constraints>
@@ -256,22 +256,22 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="60" id="nhI-Bt-xm6">
-                                        <rect key="frame" x="0.0" y="115.5" width="375" height="60"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="50" id="nhI-Bt-xm6">
+                                        <rect key="frame" x="0.0" y="105.5" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nhI-Bt-xm6" id="KR4-UZ-U11">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="59.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="49.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CY7-Ib-LAZ">
-                                                    <rect key="frame" x="301" y="14.5" width="51" height="31"/>
+                                                    <rect key="frame" x="301" y="9.5" width="51" height="31"/>
                                                     <color key="onTintColor" red="0.27058823529411763" green="0.26666666666666666" blue="0.72156862745098038" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <connections>
                                                         <action selector="onJoinedActivityNotificationChange" destination="l1g-GD-m4H" eventType="valueChanged" id="mba-yN-zur"/>
                                                     </connections>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Joined Activities" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dHL-Ec-dCv">
-                                                    <rect key="frame" x="26" y="21" width="265" height="18"/>
+                                                    <rect key="frame" x="26" y="16" width="265" height="18"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -290,33 +290,45 @@
                             </tableViewSection>
                             <tableViewSection headerTitle="Account Actions" id="EfG-IG-4ek">
                                 <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="98" id="UHc-FF-sdP">
-                                        <rect key="frame" x="0.0" y="231.5" width="375" height="98"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="50" id="UHc-FF-sdP">
+                                        <rect key="frame" x="0.0" y="211.5" width="375" height="50"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UHc-FF-sdP" id="BpQ-lw-JsN">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="97.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="49.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VHx-ke-qXu">
-                                                    <rect key="frame" x="157.5" y="15" width="60" height="30"/>
+                                                    <rect key="frame" x="157.5" y="10" width="60" height="30"/>
                                                     <state key="normal" title="Sign Out"/>
                                                     <connections>
                                                         <action selector="signOut:" destination="l1g-GD-m4H" eventType="touchUpInside" id="yLq-zJ-pJw"/>
                                                     </connections>
                                                 </button>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4dy-kY-hCk">
-                                                    <rect key="frame" x="135" y="53" width="105" height="30"/>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="VHx-ke-qXu" firstAttribute="centerY" secondItem="BpQ-lw-JsN" secondAttribute="centerY" id="NW2-fk-gDq"/>
+                                                <constraint firstItem="VHx-ke-qXu" firstAttribute="centerX" secondItem="BpQ-lw-JsN" secondAttribute="centerX" id="rdy-IH-8s8"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="50" id="H72-78-dcb">
+                                        <rect key="frame" x="0.0" y="261.5" width="375" height="50"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="H72-78-dcb" id="Kge-fy-1W5">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="49.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hUS-PC-TaY">
+                                                    <rect key="frame" x="135" y="10" width="105" height="30"/>
                                                     <state key="normal" title="Delete Account"/>
                                                     <connections>
-                                                        <action selector="deleteAccount:" destination="l1g-GD-m4H" eventType="touchUpInside" id="FRG-Gd-2Ud"/>
+                                                        <action selector="deleteAccount:" destination="l1g-GD-m4H" eventType="touchUpInside" id="oUo-kb-l0y"/>
                                                     </connections>
                                                 </button>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="4dy-kY-hCk" firstAttribute="top" secondItem="VHx-ke-qXu" secondAttribute="bottom" constant="8" id="6xG-Ne-BLC"/>
-                                                <constraint firstItem="VHx-ke-qXu" firstAttribute="centerX" secondItem="BpQ-lw-JsN" secondAttribute="centerX" id="PYZ-h4-kOl"/>
-                                                <constraint firstItem="VHx-ke-qXu" firstAttribute="top" secondItem="BpQ-lw-JsN" secondAttribute="top" constant="15" id="So4-jT-lRN"/>
-                                                <constraint firstItem="4dy-kY-hCk" firstAttribute="centerX" secondItem="BpQ-lw-JsN" secondAttribute="centerX" id="v7a-WO-iAd"/>
+                                                <constraint firstItem="hUS-PC-TaY" firstAttribute="centerX" secondItem="Kge-fy-1W5" secondAttribute="centerX" id="16Z-Ly-7oy"/>
+                                                <constraint firstItem="hUS-PC-TaY" firstAttribute="centerY" secondItem="Kge-fy-1W5" secondAttribute="centerY" id="Q8b-bg-zTW"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -326,7 +338,7 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="Settings" id="fsy-c3-78G"/>
                     <connections>
-                        <outlet property="deleteAcctButton" destination="4dy-kY-hCk" id="0gd-x2-5Xz"/>
+                        <outlet property="deleteAcctButton" destination="hUS-PC-TaY" id="9KJ-dF-v2u"/>
                         <outlet property="joinedActivityNotificationToggle" destination="CY7-Ib-LAZ" id="i6U-dK-Nxt"/>
                         <outlet property="signOutButton" destination="VHx-ke-qXu" id="thc-uP-HAU"/>
                         <outlet property="topicNotificationToggle" destination="2my-lj-ZcM" id="gbj-QE-OGL"/>
@@ -371,7 +383,7 @@
                     </cells>
                 </tableViewSection>
             </objects>
-            <point key="canvasLocation" x="1209" y="611"/>
+            <point key="canvasLocation" x="1208.8" y="610.34482758620697"/>
         </scene>
     </scenes>
     <resources>

--- a/Buddies/Storyboards/ViewActivity.storyboard
+++ b/Buddies/Storyboards/ViewActivity.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,7 +20,19 @@
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gkP-p0-4aG">
                                 <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You can't see this activity." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q8m-H2-u3E">
+                                        <rect key="frame" x="89" y="313" width="197" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="Q8m-H2-u3E" firstAttribute="centerX" secondItem="gkP-p0-4aG" secondAttribute="centerX" id="JIr-5R-38h"/>
+                                    <constraint firstItem="Q8m-H2-u3E" firstAttribute="centerY" secondItem="gkP-p0-4aG" secondAttribute="centerY" id="nhG-qe-tpH"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -35,6 +47,7 @@
                     <navigationItem key="navigationItem" id="98Q-40-Z2O"/>
                     <connections>
                         <outlet property="contentArea" destination="gkP-p0-4aG" id="5oK-dY-hhu"/>
+                        <outlet property="errorText" destination="Q8m-H2-u3E" id="L72-Hb-vg7"/>
                         <segue destination="DIj-N1-ehB" kind="show" identifier="showOtherUser" id="J0F-qZ-Ch5"/>
                     </connections>
                 </viewController>

--- a/Buddies/Utilities/ActivityTableDataListener.swift
+++ b/Buddies/Utilities/ActivityTableDataListener.swift
@@ -65,12 +65,14 @@ class ActivityTableDataListener {
                         // DNE yet, but the activity is nil
                         self.handledActivities[id] = false
                     } else if let activity = activity {
-                        // Update the activity in the table:
-                        newActivities[i][j] = activity
                         // Already exists, and we have an activity
-                        if (self.didFinishSetup) {
-                            self.delegate?.updateActivityInSection(activity: activity, section: i)
-                            self.delegate?.onOperationsFinished()
+                        // Update the activity in the table if it is different:
+                        if (activity != newActivities[i][j]) {
+                            newActivities[i][j] = activity
+                            if (self.didFinishSetup) {
+                                self.delegate?.updateActivityInSection(activity: activity, section: i)
+                                self.delegate?.onOperationsFinished()
+                            }
                         }
                         self.handledActivities[id] = true
                     } else {

--- a/BuddiesTests/Activities/ActivityListTest.swift
+++ b/BuddiesTests/Activities/ActivityListTest.swift
@@ -24,6 +24,7 @@ class ActivityListTest: XCTestCase {
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
                                 locationText: "What up buddy",
+                                bannedUsers: [],
                                 topicIds: [])
 
     func createActivity(id: String) -> Activity {
@@ -38,6 +39,7 @@ class ActivityListTest: XCTestCase {
                  startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                  endTime: Timestamp(date: "11/24/1998".toDate()!.date),
                  locationText: "What up buddy",
+                 bannedUsers: [],
                  topicIds: [])
     }
 

--- a/BuddiesTests/Activities/ActivityTableVCTests.swift
+++ b/BuddiesTests/Activities/ActivityTableVCTests.swift
@@ -24,6 +24,7 @@ class ActivityTableVCTests: XCTestCase {
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
                                 locationText: "What up buddy",
+                                bannedUsers: [],
                                 topicIds: [])
   
     // For testLoadData
@@ -130,6 +131,7 @@ class ActivityTableVCTests: XCTestCase {
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
                                 locationText: locationText,
+                                bannedUsers: [],
                                 topicIds: [])
         
         
@@ -180,6 +182,7 @@ class ActivityTableVCTests: XCTestCase {
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
                                 locationText: locationText,
+                                bannedUsers: [],
                                 topicIds: [])
         activity.users = [thisUser]
         cell.format(using: activity)
@@ -230,6 +233,7 @@ class ActivityTableVCTests: XCTestCase {
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
                                 locationText: locationText,
+                                bannedUsers: [],
                                 topicIds: [])
         
         activity.users = [thisUser, thisUser, thisUser, thisUser]

--- a/BuddiesTests/Models/UserTests.swift
+++ b/BuddiesTests/Models/UserTests.swift
@@ -13,6 +13,29 @@ import FirebaseFirestore
 @testable import Buddies
 
 class UserTests: XCTestCase {
+    let testDate = Date()
+    func createActivity(id: String) -> Activity {
+        return Activity.init(delegate: nil,
+                             activityId: id,
+                             dateCreated: Timestamp(date: Date()),
+                             members: [],
+                             location: GeoPoint(latitude: 0, longitude: 0),
+                             ownerId: "ownerId",
+                             title: "title",
+                             description: "description",
+                             startTime: Timestamp(date: testDate),
+                             endTime: Timestamp(date: testDate),
+                             locationText: "What up buddy",
+                             bannedUsers: [],
+                             topicIds: [])
+    }
+    func createOtherUser(id: String) -> OtherUser {
+        return OtherUser.init(uid: id, imageUrl: "image_url", imageVersion: 0, dateJoined: testDate, name: "Test User", bio: "This is my bio", favoriteTopics: [])
+    }
+    func createLoggedInUser(id: String) -> LoggedInUser {
+        return LoggedInUser.init(delegate: nil, imageUrl: "howdy", imageVersion: 0, isAdmin: false, uid: id, name: "my name is bob", bio: "not bob", email: "bob", facebookId: nil, favoriteTopics: ["a"], blockedUsers: [], blockedBy: [], blockedActivities: [], dateJoined: testDate, location: nil, shouldSendJoinedActivityNotification: false, shouldSendActivitySuggestionNotification: false, filterSettings: [:], notificationToken: nil, chatReadAt: [:])
+    }
+
     class TestDeli : LoggedInUserInvalidationDelegate {
         var invalidations = 0
         var triggers = 0
@@ -37,14 +60,14 @@ class UserTests: XCTestCase {
             "name" : "Test User",
             "bio" : "This is my bio\nDo you like it?",
             "email" : "fake@example.com",
-            "date_joined" : Timestamp(date: Date())
+            "date_joined" : Timestamp(date: testDate)
         ], docId: "my_uid"), with: deli)
         
         otherUser = Buddies.OtherUser.from(snap: MockDocumentSnapshot(data: [
             "image_url" : "image_url",
             "name" : "Test User",
             "bio" : "This is my bio",
-            "date_joined" : Timestamp(date: Date())
+            "date_joined" : Timestamp(date: testDate)
         ], docId: "their_uid"))
     }
     
@@ -79,5 +102,95 @@ class UserTests: XCTestCase {
         XCTAssert(otherUser.name == "Test User")
         XCTAssert(otherUser.uid == "their_uid")
         XCTAssert(otherUser.bio == "This is my bio")
+    }
+    
+    func testOtherUserEquality() {
+        let user1 = createOtherUser(id: "hi fam")
+        XCTAssertFalse(user1.isEqual(to: user))
+        
+        let user2 = createOtherUser(id: "my_uid")
+        let user3 = createOtherUser(id: "my_uid")
+        XCTAssertTrue(user2.isEqual(to: user3))
+        
+        XCTAssertTrue(user2 == user3)
+    }
+    
+    func testCurUserEquality() {
+        let user1 = createLoggedInUser(id: "hi fam")
+        XCTAssertFalse(user1.isEqual(to: user))
+        
+        let user2 = createLoggedInUser(id: "my_uid")
+        let user3 = createLoggedInUser(id: "my_uid")
+        XCTAssertTrue(user2.isEqual(to: user3))
+        
+        XCTAssertTrue(user2 == user3)
+    }
+
+    func testIsBlocked() {
+        let user1 = createLoggedInUser(id: "me")
+        user1.blockedUsers = ["me"]
+        XCTAssertTrue(user1.isBlocked(user: "me"))
+    }
+
+    func testIsBlocked1() {
+        let user1 = createLoggedInUser(id: "me")
+        XCTAssertFalse(user1.isBlocked(user: nil))
+    }
+
+    func testIsActivityBlocked() {
+        let user1 = createLoggedInUser(id: "me")
+        XCTAssertFalse(user1.isBlocked(activity: nil))
+    }
+    
+    func testIsActivityBlocked2() {
+        let user1 = createLoggedInUser(id: "me")
+        let activity = createActivity(id: "this activity tho")
+        activity.bannedUsers = [ "me" ]
+        XCTAssertTrue(user1.isBlocked(activity: activity))
+    }
+    
+    func testIsActivityBlocked3() {
+        let user1 = createLoggedInUser(id: "me")
+        user1.blockedActivities = [ "meme big boy" ]
+        let activity = createActivity(id: "meme big boy")
+        XCTAssertTrue(user1.isBlocked(activity: activity))
+    }
+    
+    func testIsActivityBlocked4() {
+        let user1 = createLoggedInUser(id: "me")
+        user1.blockedUsers = [ "not me" ]
+        let activity = createActivity(id: "meme big boy")
+        activity.members = [ "not me" ]
+        XCTAssertTrue(user1.isBlocked(activity: activity))
+    }
+    
+    func testIsActivityBlocked5() {
+        let user1 = createLoggedInUser(id: "me")
+        let activity = createActivity(id: "meme big boy")
+        XCTAssertFalse(user1.isBlocked(activity: activity))
+    }
+    
+    func testUserBlockListDiff() {
+        let user1 = createLoggedInUser(id: "me")
+        let user2 = createLoggedInUser(id: "them")
+        user2.blockedUsers = ["hi"]
+        XCTAssertTrue(user1.isUserBlockListDifferent(user2))
+    }
+
+    func testUserBlockListDiff2() {
+        let user1 = createLoggedInUser(id: "me")
+        XCTAssertFalse(user1.isUserBlockListDifferent(nil))
+    }
+    
+    func testActivityBlockListDiff() {
+        let user1 = createLoggedInUser(id: "me")
+        let user2 = createLoggedInUser(id: "them")
+        user2.blockedActivities = ["hi"]
+        XCTAssertTrue(user1.isActivityBlockListDifferent(user2))
+    }
+    
+    func testActivityBlockListDiff2() {
+        let user1 = createLoggedInUser(id: "me")
+        XCTAssertFalse(user1.isActivityBlockListDifferent(nil))
     }
 }

--- a/BuddiesTests/Utilities/ActivityTableDataListenerTest.swift
+++ b/BuddiesTests/Utilities/ActivityTableDataListenerTest.swift
@@ -23,6 +23,7 @@ class ActivityTableDataListenerTest: XCTestCase {
                                 startTime: Timestamp(date: "11/23/1998".toDate()!.date),
                                 endTime: Timestamp(date: "11/24/1998".toDate()!.date),
                                 locationText: "What up buddy",
+                                bannedUsers: [],
                                 topicIds: [])
 
     var dataAccessor: DataAccessor!


### PR DESCRIPTION
This PR introduces client-side changes to support blocking and banning users.

There are a lot of cases you can test. For example, you can test reporting an activity that you've joined, and one that you haven't joined. Note that it may take a few seconds after reporting for changes to happen.

Also, I tried to cover the User and Activity models with a lot of tests, so that should maintain a bit of coverage.

### To Test:
1. Try reporting an activity. After you do so, you should no longer be able to see the activity anywhere. (And, from the POV of the people in the activity, you should no longer be a member)
2. Try reporting a user from an activity you are not in. After you do so, you should no longer be able to see any activities in which that user appears.
3. Try reporting a user from an activity you've joined. You should no longer be able to see any activities in which that user appears _and_ you should be removed from all of the activities you shared with that person.
4. With two different accounts, test banning a user. One account should own the activity, and the other account should join it. The owner should remove the user, and the removed user should _immediately_ see the "you can't see this activity" message while they are looking at the activity.
