### PR TITLE
Remove notification token when logging out

### DIFF
--- a/Buddies/Onboarding/AuthHandler.swift
+++ b/Buddies/Onboarding/AuthHandler.swift
@@ -101,8 +101,17 @@ class AuthHandler {
         }
     }
     
-    func signOut(onError: (String) -> Void, onSuccess: () -> Void) {
+    func signOut(onError: @escaping (String) -> Void, onSuccess: () -> Void) {
         do {
+            let collection: CollectionReference = Firestore.firestore().collection("accounts")
+            guard let uid = auth.currentUser?.uid else { return }
+            collection.document(uid).setData([
+                "notification_token" : ""
+            ], merge: true) { err in
+                if let err = err {
+                    onError("Could not update notification token: \(err)")
+                }
+            }
             try auth.signOut()
             onSuccess()
         }


### PR DESCRIPTION
Fixes #123 

If you have a real device, test by
1. make sure you get notifications while you're logged in (though the app has to be in the background).
2. Log out
3. Test that you no longer get notifications that you would otherwise get