### PR TITLE
Blocked chat users

### DIFF
--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -278,6 +278,8 @@ extension ActivityChatController: MessagesDisplayDelegate {
     
     func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {
         
+        avatarView.isHidden = false
+        
         //hide avatar if from system
         if message.sender.id == "system"{
             avatarView.isHidden = true

--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -314,9 +314,6 @@ extension ActivityChatController: MessagesLayoutDelegate {
         }
     }
     
-    func messageBottomLabelHeight(for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) -> CGFloat {
-        return (message.sender.id == "system") ? 16 : 0
-    }
     
     
 }

--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -44,6 +44,7 @@ class ActivityChatController: MessagesViewController {
         loadMessageList()
         messageList = messageList.sorted { $0.sentDate < $1.sentDate }
         messagesCollectionView.reloadData()
+        messageInputBar.inputTextView.resignFirstResponder()
         messagesCollectionView.scrollToBottom(animated: true)
         
     }

--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -109,11 +109,12 @@ class ActivityChatController: MessagesViewController {
                     
                     let sender = Sender(id: id , displayName: self.getUserName(id: id))
                     
-                    //if message about user leaving or joining
+                    //if message from system
                     if data["type"] as! String != "message" {
                         let systemSender = Sender(id: "system", displayName: "")
+                        let content =  NSAttributedString(string: data["message"] as! String, attributes: [NSAttributedString.Key.font: UIFont.italicSystemFont(ofSize: 14)])
                         
-                        return Message(text: data["message"] as! String, sender: systemSender, messageId: doc.documentID, date: (data["date_sent"] as! Timestamp).dateValue())
+                        return Message(text: content, sender: systemSender, messageId: doc.documentID, date: (data["date_sent"] as! Timestamp).dateValue())
                     }
                     
                     return Message(text: data["message"] as! String, sender: sender, messageId: doc.documentID, date: (data["date_sent"] as! Timestamp).dateValue())
@@ -174,6 +175,7 @@ extension ActivityChatController: MessagesDataSource {
         }
         return nil
     }
+
     
     func messageTopLabelAttributedText(for message: MessageType, at indexPath: IndexPath) -> NSAttributedString? {
         if !isPreviousMessageSameSender(at: indexPath) {
@@ -269,9 +271,9 @@ extension ActivityChatController: MessagesDisplayDelegate {
             
             return .bubbleTail(tail, .curved)
         }
-        
-
     }
+    
+    
     
     
     func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {

--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -15,6 +15,7 @@ class ActivityChatController: MessagesViewController {
     @IBOutlet weak var statusLabel: UILabel!
     
     var messageList: [Message] = []
+    var userList: [User] = []
 
     // Local data for rendering:
     var activity: Activity?
@@ -23,14 +24,17 @@ class ActivityChatController: MessagesViewController {
     var userCanceler: Canceler?
     var registration: ListenerRegistration?
     
+    
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        messageList = messageList.sorted { $0.sentDate < $1.sentDate }
+        
         messagesCollectionView.messagesDataSource = self
         messagesCollectionView.messagesLayoutDelegate = self
         messagesCollectionView.messagesDisplayDelegate = self
+        messagesCollectionView.messageCellDelegate = self
         messageInputBar.delegate = self
+        scrollsToBottomOnKeyboardBeginsEditing = true
         messageInputBar.tintColor = Theme.theme
         
         userCanceler = DataAccessor.instance.useLoggedInUser { user in
@@ -38,6 +42,7 @@ class ActivityChatController: MessagesViewController {
         }
         
         loadMessageList()
+        messageList = messageList.sorted { $0.sentDate < $1.sentDate }
         messagesCollectionView.reloadData()
         messagesCollectionView.scrollToBottom(animated: true)
         
@@ -50,7 +55,6 @@ class ActivityChatController: MessagesViewController {
     
     func getUserName(id:String) -> String{
         
-        guard let userList = activity?.users else {return ""}
         var name = ""
         for user in userList{
             if user.uid == id{
@@ -62,7 +66,6 @@ class ActivityChatController: MessagesViewController {
     
     func getAvatarImage(id:String) -> UIImage?{
         
-        guard let userList = activity?.users else {return nil}
         for user in userList{
             if user.uid == id{
                 return user.image
@@ -83,6 +86,8 @@ class ActivityChatController: MessagesViewController {
             }
             
         }
+        
+        
         
     }
     
@@ -215,6 +220,7 @@ extension ActivityChatController: MessageInputBarDelegate {
 // MARK: - MessagesDisplayDelegate
 extension ActivityChatController: MessagesDisplayDelegate {
     
+    
     // MARK: - Helpers
     func isTimeLabelVisible(at indexPath: IndexPath) -> Bool {
         return indexPath.section % 3 == 0 && !isPreviousMessageSameSender(at: indexPath)
@@ -262,8 +268,10 @@ extension ActivityChatController: MessagesDisplayDelegate {
             
             return .bubbleTail(tail, .curved)
         }
+        
 
     }
+    
     
     func configureAvatarView(_ avatarView: AvatarView, for message: MessageType, at indexPath: IndexPath, in messagesCollectionView: MessagesCollectionView) {
         
@@ -279,6 +287,7 @@ extension ActivityChatController: MessagesDisplayDelegate {
             
             avatarView.set(avatar:avi)
         }
+        
       
     }
     
@@ -306,5 +315,15 @@ extension ActivityChatController: MessagesLayoutDelegate {
         return (message.sender.id == "system") ? 16 : 0
     }
     
+    
+}
+
+// MARK: - MessageCellDelegate
+
+extension ActivityChatController: MessageCellDelegate {
+    
+    func didTapMessage(in cell: MessageCollectionViewCell) {
+        messageInputBar.inputTextView.resignFirstResponder()
+    }
     
 }

--- a/Buddies/Activities/View Activity/ViewActivityController.swift
+++ b/Buddies/Activities/View Activity/ViewActivityController.swift
@@ -336,6 +336,7 @@ class ViewActivityController: UIViewController {
                     self.addChild(chatController)
                     chatController.didMove(toParent: self)
                     chatController.activity = activity
+                    chatController.userList = activityUsers ?? []
                     chatController.loadMessageList()
                     
                     becomeFirstResponder()

--- a/Buddies/Activities/View Activity/ViewActivityController.swift
+++ b/Buddies/Activities/View Activity/ViewActivityController.swift
@@ -74,7 +74,6 @@ class ViewActivityController: UIViewController {
         
         reportButton.tintColor = Theme.bad
         
-        setupHideKeyboardOnTap()
     }
 
     // Need to wait to render until here
@@ -340,8 +339,6 @@ class ViewActivityController: UIViewController {
                     chatController.loadMessageList()
                     
                     becomeFirstResponder()
-                    
-                    chatController.messageInputBar.inputTextView.becomeFirstResponder()
                     
                     //adjust height
                     chatController.view.bindFrameToSuperviewBounds()

--- a/Buddies/Models/Message.swift
+++ b/Buddies/Models/Message.swift
@@ -25,6 +25,14 @@ class Message: MessageType {
         self.sentDate = date
         self.content = text
     }
+    
+    init(text: NSAttributedString, sender: Sender, messageId: String, date: Date) {
+        self.kind = .attributedText(text)
+        self.sender = sender
+        self.messageId = messageId
+        self.sentDate = date
+        self.content = text.string
+    }
 
     
 }


### PR DESCRIPTION
Users have been blocked and subsequently removed from a chat have their messages redacted to say "This user has been removed." Messages sent by users that have joined and simply left on their own are retained. This also add mini QoL changes.

To Test:
- join an activity with two different accounts
- sends messages with both accounts
- leave with one account & ensure messages are still present for the other
- join again and block a user
- ensure the messages have been redacted

To Do:

- [x] fix avatar inconsistency