### PR TITLE
Tap profile pic chat

### DIFF
--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -345,7 +345,9 @@ extension ActivityChatController: MessageCellDelegate {
             
             let userID = msg.sender.id
             
-            if activity?.getMemberStatus(of: userID) != .banned {
+            let memberStatus = activity?.getMemberStatus(of: userID)
+            
+            if  memberStatus == .owner || memberStatus == .member{
                  tapUser(userID)
             }
 

--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -345,7 +345,10 @@ extension ActivityChatController: MessageCellDelegate {
             
             let userID = msg.sender.id
             
-            tapUser(userID)
+            if activity?.getMemberStatus(of: userID) != .banned {
+                 tapUser(userID)
+            }
+
             
         }
         

--- a/Buddies/Activities/View Activity/ActivityChatController.swift
+++ b/Buddies/Activities/View Activity/ActivityChatController.swift
@@ -54,6 +54,13 @@ class ActivityChatController: MessagesViewController {
         registration?.remove()
     }
     
+    func tapUser(_ uid: String) {
+        if let userProfile = BuddiesStoryboard.OtherProfile.viewController(withID: "otherProfile") as? OtherProfileVC {
+            userProfile.userId = uid
+            self.navigationController?.pushViewController(userProfile, animated: true)
+        }
+    }
+    
     func getUserName(id:String) -> String{
         
         var name = ""
@@ -320,12 +327,31 @@ extension ActivityChatController: MessagesLayoutDelegate {
     
 }
 
-// MARK: - MessageCellDelegate
 
+
+// MARK: - MessageCellDelegate
 extension ActivityChatController: MessageCellDelegate {
     
     func didTapMessage(in cell: MessageCollectionViewCell) {
         messageInputBar.inputTextView.resignFirstResponder()
     }
     
+    func didTapAvatar(in cell: MessageCollectionViewCell) {
+        
+        //get index path from cell
+        if let indexPath = messagesCollectionView.indexPath(for: cell){
+            
+            let msg = messageForItem(at: indexPath, in: messagesCollectionView)
+            
+            let userID = msg.sender.id
+            
+            tapUser(userID)
+            
+        }
+        
+       
+        
+    }
+    
 }
+

--- a/Buddies/Activities/View Activity/ViewActivityController.swift
+++ b/Buddies/Activities/View Activity/ViewActivityController.swift
@@ -182,12 +182,6 @@ class ViewActivityController: UIViewController {
     var shouldExpand = false
     func expandDescription() {
         shouldExpand = !shouldExpand
-        if shouldExpand {
-            //resignFirstResponder()
-        }else
-        {
-            //becomeFirstResponder()
-        }
         render()
     }
 
@@ -337,6 +331,7 @@ class ViewActivityController: UIViewController {
                     chatController.activity = activity
                     chatController.userList = activityUsers ?? []
                     chatController.loadMessageList()
+                    chatController.messagesCollectionView.reloadData()
                     
                     becomeFirstResponder()
                     


### PR DESCRIPTION
You can now go to user's profile by tapping on their avatar if they are a member.

To Test
- join an activity
- tap a member's profile picture in chat
- tap the owner's profile picture in chat
- tap the profile picture of a user who has left the activity
- tap the profile picture of a user who was removed from the activity

To Do

- [x] Load messages correctly (i.e. without having to send a message)