### PR TITLE
Add help text if you have no favorited topics

### DIFF
--- a/Buddies/Discover/DiscoverTableVC.swift
+++ b/Buddies/Discover/DiscoverTableVC.swift
@@ -22,7 +22,10 @@ class DiscoverTableVC : ActivityTableVC {
 
     
     override func checkAndShowNoActivitiesMessage () {
-        if (self.dataSource.hasNoActivities() && getTopics().count == 0) {
+        let searchParams = searchBar.getSearchParams()
+        let hasTextParam: Bool = !(searchParams.filterText?.isEmpty ?? true)
+
+        if (!hasTextParam && dataSource.hasNoActivities() && getTopics().count == 0) {
                 tableView.setEmptyMessage("Discover suggests Activities based on your favorite Topics. \n\nVisit the Topics tab to select Topics you love! 😊\n\n\n\n\n\n")
         } else {
            super.checkAndShowNoActivitiesMessage()

--- a/Buddies/Discover/DiscoverTableVC.swift
+++ b/Buddies/Discover/DiscoverTableVC.swift
@@ -19,6 +19,15 @@ class DiscoverTableVC : ActivityTableVC {
     var cancelUserListener: Canceler?
     
     var geoPrecisionGroups = 3.0
+
+    
+    override func checkAndShowNoActivitiesMessage () {
+        if (self.dataSource.hasNoActivities() && getTopics().count == 0) {
+                tableView.setEmptyMessage("Discover suggests Activities based on your favorite Topics. \n\nVisit the Topics tab to select Topics you love! 😊\n\n\n\n\n\n")
+        } else {
+           super.checkAndShowNoActivitiesMessage()
+        }
+    }
     
     override func viewDidLoad() {
         self.setupHideKeyboardOnTap()
@@ -50,7 +59,14 @@ class DiscoverTableVC : ActivityTableVC {
     override func fetchAndLoadActivities() {
         self.startRefreshIndicator()
         let searchParams = searchBar.getSearchParams()
-        let topics = (searchParams.filterText?.isEmpty ?? true) ? getTopics() : []
+        let hasTextParam: Bool = !(searchParams.filterText?.isEmpty ?? true)
+        //If no topics and no query, hide results to show onboarding
+        guard hasTextParam || getTopics().count > 0 else {
+            self.updateWantedActivities(with: [[]])
+            return
+        }
+        
+        let topics = hasTextParam ? [] : getTopics()
         
                 
         //Sort into `geoPrecisionGroups` number of groups

--- a/Buddies/Discover/DiscoverTableVC.swift
+++ b/Buddies/Discover/DiscoverTableVC.swift
@@ -60,7 +60,9 @@ class DiscoverTableVC : ActivityTableVC {
         self.startRefreshIndicator()
         let searchParams = searchBar.getSearchParams()
         let hasTextParam: Bool = !(searchParams.filterText?.isEmpty ?? true)
-        //If no topics and no query, hide results to show onboarding
+        
+        //Hacky way of displaying Onboarding message
+        // If topics or search param, do search. Otherwise onboarding msg
         guard hasTextParam || getTopics().count > 0 else {
             self.updateWantedActivities(with: [[]])
             return

--- a/Buddies/_ThirdParty/EmptyMessageBackground.swift
+++ b/Buddies/_ThirdParty/EmptyMessageBackground.swift
@@ -9,6 +9,19 @@
 //
 import UIKit
 
+//Wacky (not quite hacky) way of adding padding
+extension UIView {
+    func withPadding(_ padding: UIEdgeInsets) -> UIView {
+        let container = UIView()
+        self.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(self)
+        container.addConstraints(NSLayoutConstraint.constraints( withVisualFormat: "|-(\(padding.left))-[view]-(\(padding.right))-|" , options: [], metrics: nil, views: ["view": self]))
+        container.addConstraints(NSLayoutConstraint.constraints( withVisualFormat: "V:|-(\(padding.top))-[view]-(\(padding.bottom))-|", options: [], metrics: nil, views: ["view": self]))
+        return container
+    }
+}
+
+
 extension UITableView {
     func setEmptyMessage(_ message: String, font: UIFont = UIFont.systemFont(ofSize: 15)) {
         let messageLabel = UILabel(frame: CGRect(x: 0, y: 0, width: self.bounds.size.width, height: self.bounds.size.height))
@@ -19,7 +32,9 @@ extension UITableView {
         messageLabel.font = font
         messageLabel.sizeToFit()
         
-        self.backgroundView = messageLabel;
+        let padding = UIEdgeInsets(top: 20, left: 20, bottom: 20, right: 20)
+        
+        self.backgroundView = messageLabel.withPadding(padding);
         self.separatorStyle = .none;
     }
     

--- a/BuddiesTests/Activities/ActivityTableVCTests.swift
+++ b/BuddiesTests/Activities/ActivityTableVCTests.swift
@@ -283,13 +283,13 @@ class ActivityTableVCTests: XCTestCase {
     
     func testNoActivities () {
         activityTableVC.checkAndShowNoActivitiesMessage()
-        let text = activityTableVC.tableView.backgroundView as? UILabel
+        let text = activityTableVC.tableView.backgroundView
         XCTAssertNotNil(text, "Text view should exist")
 
         // Add an activity:
         let _ = activityTableVC.dataSource.setActivities([[testActivity]])
         activityTableVC.checkAndShowNoActivitiesMessage()
-        let text2 = activityTableVC.tableView.backgroundView as? UILabel
+        let text2 = activityTableVC.tableView.backgroundView
         XCTAssertNil(text2, "Text view should not exist")
     }
     


### PR DESCRIPTION
* Now there's helptext if you have no favorited topics
* You can still search text
    * Results should show up if you give a search that has results
    * If there are no results, it will still give you the onboarding text, not "No Results" which would be better
* If you favorite a topic, it goes away.  There is a little bit of a delay before the text goes away (same issue with "No Results" text)
    * If it's an issue, lmk

To test:
* Favorite no topics
* Check it displays
* Search text, make sure that works right
* Favorite a topic with no activities in it
    * Should say "No Results" now
* Favorite a topic with activities
     * Should display Activities now