### PR TITLE
Never blocking your own activities

### DIFF
--- a/BuddiesTests/Models/UserTests.swift
+++ b/BuddiesTests/Models/UserTests.swift
@@ -128,8 +128,9 @@ class UserTests: XCTestCase {
 
     func testIsBlocked() {
         let user1 = createLoggedInUser(id: "me")
-        user1.blockedUsers = ["me"]
-        XCTAssertTrue(user1.isBlocked(user: "me"))
+        user1.blockedUsers = ["me", "not_me"]
+        XCTAssertFalse(user1.isBlocked(user: "me"))
+        XCTAssertTrue(user1.isBlocked(user: "not_me"))
     }
 
     func testIsBlocked1() {


### PR DESCRIPTION
This ensures that an activity you own will never be considered "blocked". Fixes #142 

### Testing:
1. Block a user in an activity you own. You should still be able to see the activity.
2. Block a user in an activity you don't own. After a second or two, you shouldn't be able to see the activity.