### PR TITLE
Show user images even if they aren't cached 

### DIFF
--- a/Buddies/Models/User.swift
+++ b/Buddies/Models/User.swift
@@ -44,7 +44,8 @@ class OtherUser : User, Equatable {
          dateJoined: Date,
          name: String,
          bio: String,
-         favoriteTopics: [String]) {
+         favoriteTopics: [String],
+         image: UIImage? = nil) {
         self.uid = uid
         self.imageUrl = imageUrl
         self.imageVersion = imageVersion
@@ -87,6 +88,17 @@ class OtherUser : User, Equatable {
 
     static func == (lhs: OtherUser, rhs: OtherUser) -> Bool {
         return lhs.isEqual(to: rhs)
+    }
+    
+    func copy() -> OtherUser {
+        return OtherUser(uid: uid,
+                         imageUrl: imageUrl,
+                         imageVersion: imageVersion,
+                         dateJoined: dateJoined,
+                         name: name,
+                         bio: bio,
+                         favoriteTopics: favoriteTopics,
+                         image: image)
     }
 }
 

--- a/Buddies/Utilities/DataAccessor.swift
+++ b/Buddies/Utilities/DataAccessor.swift
@@ -254,8 +254,9 @@ class DataAccessor : LoggedInUserInvalidationDelegate, ActivityInvalidationDeleg
             
             if let user = OtherUser.from(snap: snap) {
             	self.storageManager.getImage(imageUrl: user.imageUrl, localFileName: "\(user.uid)_\(user.imageVersion)") { img in
-                    user.image = img
-                    self.onInvalidateUser(user: user)
+                    let newUser = user.copy()
+                    newUser.image = img
+                    self.onInvalidateUser(user: newUser)
                 }
                 self.onInvalidateUser(user: user, id: id)
             } else {

--- a/BuddiesTests/Models/UserTests.swift
+++ b/BuddiesTests/Models/UserTests.swift
@@ -194,4 +194,11 @@ class UserTests: XCTestCase {
         let user1 = createLoggedInUser(id: "me")
         XCTAssertFalse(user1.isActivityBlockListDifferent(nil))
     }
+    
+    func testCopyEquality() {
+        let user1 = createOtherUser(id: "user1")
+        let user2 = user1.copy()
+        XCTAssert(user1 !== user2, "Copy creates a new object")
+        XCTAssert(user1 == user2, "Copy creates a functionally identical copy")
+    }
 }


### PR DESCRIPTION
Fixes the bug where user images don't show up if they haven't already been cached.  

This adds a `copy` function.  We probably shouldn't have designed the User protocol to require a mutable `image`, and instead just make a copy with an image when we set it, but I wanted to make minimal changes so I didn't touch that.

To test
* Delete the app
* Run the app
* All user profiles should load after a moment (to test even better, put yourself in a bad internet situation and increase the delay lol)

I'll wait for 2 approvals before merging this, since it's so close to the end.