### PR TITLE
Fix bug with pics not showing up

### DIFF
--- a/Buddies/Utilities/DataAccessor.swift
+++ b/Buddies/Utilities/DataAccessor.swift
@@ -185,9 +185,8 @@ class DataAccessor : LoggedInUserInvalidationDelegate, ActivityInvalidationDeleg
             } else if let user = user {
                 // The user has been loaded, so we want to update this user.
                 if let index = users.firstIndex(where: { $0.uid == uid }) {
-                    let oldUser = users[index]
                     users[index] = user
-                    if (oldUser.image == nil && user.image != nil && didFinishSetup) {
+                    if (didFinishSetup) {
                         fn(users)
                     }
                 }
@@ -254,9 +253,8 @@ class DataAccessor : LoggedInUserInvalidationDelegate, ActivityInvalidationDeleg
             
             if let user = OtherUser.from(snap: snap) {
             	self.storageManager.getImage(imageUrl: user.imageUrl, localFileName: "\(user.uid)_\(user.imageVersion)") { img in
-                    let newUser = user.copy()
-                    newUser.image = img
-                    self.onInvalidateUser(user: newUser)
+                    user.image = img
+                    self.onInvalidateUser(user: user)
                 }
                 self.onInvalidateUser(user: user, id: id)
             } else {


### PR DESCRIPTION
For some reason, the app hated having a different memory reference for activities. This reverts the code which makes a new copy when the image change. This fixes the new bug.

In order to fix the bug with the cached images, I removed the equality check which caused it. Luke was getting around this by changing the memory reference. Previously this failed because `oldUser === user` so it just plumb compared it to the same thing.

I originally had added this check to reduce flashing on the lists as things load. However, after testing here, it does _not_ seem as if we still have that issue. I think there is another equality check somewhere else which is helping with that.

I'll also only merge this after getting approval from 2 people.

## To Test:
1. Use a _new_ simulator that you haven't used before to ensure no cache sticks around. For some reason firebase stays logged in even when you delete the app.
2. First, log in. All user pictures should load after a brief pause. (This fixes the first bug)
3. Next, make sure that all user pictures are showing up in _all_ activities. Make sure there are no gray circles anywhere.
4. Try re-opening the app and make sure it still works